### PR TITLE
feat: add dark vessel / AIS gap detection module

### DIFF
--- a/aisdb/anomaly/__init__.py
+++ b/aisdb/anomaly/__init__.py
@@ -1,3 +1,7 @@
 from .dark_vessel import DarkVesselDetector, DarkEvent, flag_dark_gaps
+from .lstm_anomaly import TrajectoryAnomalyDetector, AnomalyEvent, flag_anomalies
 
-__all__ = ['DarkVesselDetector', 'DarkEvent', 'flag_dark_gaps']
+__all__ = [
+    'DarkVesselDetector', 'DarkEvent', 'flag_dark_gaps',
+    'TrajectoryAnomalyDetector', 'AnomalyEvent', 'flag_anomalies',
+]

--- a/aisdb/anomaly/__init__.py
+++ b/aisdb/anomaly/__init__.py
@@ -1,0 +1,3 @@
+from .dark_vessel import DarkVesselDetector, DarkEvent, flag_dark_gaps
+
+__all__ = ['DarkVesselDetector', 'DarkEvent', 'flag_dark_gaps']

--- a/aisdb/anomaly/__init__.py
+++ b/aisdb/anomaly/__init__.py
@@ -1,7 +1,9 @@
 from .dark_vessel import DarkVesselDetector, DarkEvent, flag_dark_gaps
 from .lstm_anomaly import TrajectoryAnomalyDetector, AnomalyEvent, flag_anomalies
+from .spoof_detect import SpoofingDetector, SpoofEvent, flag_spoofing
 
 __all__ = [
     'DarkVesselDetector', 'DarkEvent', 'flag_dark_gaps',
     'TrajectoryAnomalyDetector', 'AnomalyEvent', 'flag_anomalies',
+    'SpoofingDetector', 'SpoofEvent', 'flag_spoofing',
 ]

--- a/aisdb/anomaly/dark_vessel.py
+++ b/aisdb/anomaly/dark_vessel.py
@@ -1,0 +1,435 @@
+'''Dark Vessel Detection — AIS Transmission Gap Analysis
+
+Detects suspicious gaps in AIS transmissions using a 2-state Gaussian HMM
+trained on normal vessel behaviour.  Vessels that suppress their AIS
+transponder while still operating ("going dark") may be engaged in illegal
+fishing, sanctions evasion, smuggling, or other activity that violates
+maritime law.
+
+Gap reporting-rate priors are informed by ITU-R M.1371-5:
+  - Class A underway  :  2 – 10 s
+  - Class A at anchor :  3 min
+  - Class B           :  30 s – 3 min
+  - Fishing vessels   :  3 min  (often Class A)
+
+Two-state HMM:
+  state 0 — NORMAL  : ping interval consistent with vessel type & area
+  state 1 — DARK    : gap significantly exceeds expected reporting rate
+
+The model is trained per vessel type from historical TrackGen output.
+When insufficient training data exist for a type the module falls back to
+a logistic rule-based scorer calibrated to the ITU thresholds above.
+
+Typical pipeline usage::
+
+    from aisdb.anomaly.dark_vessel import DarkVesselDetector, flag_dark_gaps
+
+    detector = DarkVesselDetector()
+    detector.fit(training_tracks)               # TrackGen generator
+    detector.save('dark_vessel_model.pkl')
+
+    detector = DarkVesselDetector.load('dark_vessel_model.pkl')
+    for track in flag_dark_gaps(live_tracks, detector, threshold=0.6):
+        for event in track['dark_events']:
+            print(event)
+'''
+
+import logging
+import pickle
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Generator, Iterable, List, Optional
+
+import numpy as np
+from hmmlearn.hmm import GaussianHMM
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# ITU-R M.1371 nominal reporting intervals (seconds) — used as HMM priors
+# ---------------------------------------------------------------------------
+
+#: Expected ping interval (seconds) per vessel category.
+REPORTING_INTERVALS: Dict[str, float] = {
+    'fishing':    180.0,
+    'tanker':      10.0,
+    'cargo':       10.0,
+    'passenger':    5.0,
+    'tug':         10.0,
+    'default':     10.0,
+}
+
+#: Gap duration (seconds) beyond which a gap is flagged by the rule-based
+#: fallback scorer (used when no trained HMM is available).
+DARK_THRESHOLDS: Dict[str, float] = {
+    'fishing':   3600.0,   # 1 hour
+    'tanker':    1800.0,   # 30 min
+    'cargo':     1800.0,
+    'passenger':  900.0,   # 15 min
+    'default':   1800.0,
+}
+
+
+# ---------------------------------------------------------------------------
+# Data class
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DarkEvent:
+    '''A detected AIS transmission gap that exceeds expected behaviour.
+
+    Attributes:
+        mmsi:         Maritime Mobile Service Identity of the vessel.
+        start_epoch:  Unix epoch seconds — last ping before the gap.
+        end_epoch:    Unix epoch seconds — first ping after the gap.
+        duration_s:   Gap length in seconds.
+        lat_before:   Latitude of last known position before gap.
+        lon_before:   Longitude of last known position before gap.
+        lat_after:    Latitude of first position after gap.
+        lon_after:    Longitude of first position after gap.
+        gap_score:    Darkness probability in [0, 1] (1 = very likely dark).
+        ship_type:    Normalised vessel type string used for scoring.
+    '''
+    mmsi: int
+    start_epoch: int
+    end_epoch: int
+    duration_s: float
+    lat_before: float
+    lon_before: float
+    lat_after: float
+    lon_after: float
+    gap_score: float
+    ship_type: str = 'unknown'
+
+    @property
+    def duration_hours(self) -> float:
+        return self.duration_s / 3600.0
+
+    @property
+    def start_dt(self) -> datetime:
+        return datetime.fromtimestamp(self.start_epoch, tz=timezone.utc).replace(tzinfo=None)
+
+    @property
+    def end_dt(self) -> datetime:
+        return datetime.fromtimestamp(self.end_epoch, tz=timezone.utc).replace(tzinfo=None)
+
+    def __repr__(self) -> str:
+        return (
+            f'DarkEvent(mmsi={self.mmsi}, '
+            f'start={self.start_dt.isoformat()}, '
+            f'duration={self.duration_hours:.2f}h, '
+            f'score={self.gap_score:.3f})'
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _normalise_ship_type(track: dict) -> str:
+    '''Return the normalised ship-type key for a track dict.'''
+    raw = track.get('ship_type_txt', '') or track.get('ship_type', '') or ''
+    raw = str(raw).lower()
+    for key in REPORTING_INTERVALS:
+        if key in raw:
+            return key
+    return 'default'
+
+
+def _gap_features(time_arr: np.ndarray) -> np.ndarray:
+    '''Compute per-gap log-duration features from a timestamp array.
+
+    Returns shape ``(n_pings - 1, 1)`` using ``log1p(seconds)`` to
+    compress the heavy tail of gap-duration distributions.
+    '''
+    if len(time_arr) < 2:
+        return np.empty((0, 1), dtype=np.float64)
+    gaps = np.diff(time_arr.astype(np.float64))
+    gaps = np.maximum(gaps, 0.0)   # guard against duplicate / unsorted timestamps
+    return np.log1p(gaps).reshape(-1, 1)
+
+
+def _rule_based_scores(time_arr: np.ndarray, ship_type: str) -> np.ndarray:
+    '''Logistic rule-based darkness scorer (no HMM required).
+
+    Returns a float array in [0, 1] for each gap — 0 = normal, 1 = dark.
+    The sigmoid is centred at the type-specific threshold with a half-width
+    of 50 % of that threshold, giving a smooth ramp rather than a hard cut.
+    '''
+    threshold = DARK_THRESHOLDS.get(ship_type, DARK_THRESHOLDS['default'])
+    if len(time_arr) < 2:
+        return np.array([], dtype=np.float64)
+    gaps = np.diff(time_arr.astype(np.float64))
+    gaps = np.maximum(gaps, 0.0)
+    x = (gaps - threshold) / (threshold * 0.5)
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+# ---------------------------------------------------------------------------
+# Core detector
+# ---------------------------------------------------------------------------
+
+class DarkVesselDetector:
+    '''Detects AIS transmission gaps using a 2-state Gaussian HMM.
+
+    One model is trained per vessel type.  If insufficient training data
+    are available for a given type the rule-based logistic scorer is used
+    transparently as a fallback.
+
+    Training example::
+
+        detector = DarkVesselDetector()
+        detector.fit(TrackGen(rowgen, decimate=True))
+        detector.save('dark_vessel_model.pkl')
+
+    Inference example::
+
+        detector = DarkVesselDetector.load('dark_vessel_model.pkl')
+        for track in detector.flag_dark_gaps(tracks, threshold=0.6):
+            for event in track['dark_events']:
+                print(event)
+    '''
+
+    #: Number of HMM states.
+    N_STATES = 2
+    NORMAL_STATE = 0
+    DARK_STATE = 1
+
+    #: Minimum number of training gaps required to fit a model for a type.
+    MIN_GAPS = 50
+
+    def __init__(self) -> None:
+        self._models: Dict[str, GaussianHMM] = {}
+        self._fitted: bool = False
+
+    # ------------------------------------------------------------------
+    # Training
+    # ------------------------------------------------------------------
+
+    def fit(self, tracks: Iterable[dict]) -> 'DarkVesselDetector':
+        '''Fit one GaussianHMM per vessel type from a collection of tracks.
+
+        args:
+            tracks: iterable of AISdb track dicts (e.g. from TrackGen).
+
+        returns:
+            self  — allows method chaining.
+        '''
+        corpus: Dict[str, List[np.ndarray]] = {}
+        for track in tracks:
+            stype = _normalise_ship_type(track)
+            feats = _gap_features(track['time'])
+            if feats.shape[0] == 0:
+                continue
+            corpus.setdefault(stype, []).append(feats)
+
+        for stype, feat_list in corpus.items():
+            all_feats = np.vstack(feat_list)
+            n_gaps = all_feats.shape[0]
+            if n_gaps < self.MIN_GAPS:
+                logger.info(
+                    'Skipping HMM for "%s": only %d gaps (need %d)',
+                    stype, n_gaps, self.MIN_GAPS,
+                )
+                continue
+
+            model = GaussianHMM(
+                n_components=self.N_STATES,
+                covariance_type='full',
+                n_iter=200,
+                random_state=42,
+            )
+            # Strong self-loop prior — the vessel spends most time in NORMAL
+            model.startprob_ = np.array([0.99, 0.01])
+            model.transmat_ = np.array([[0.99, 0.01],
+                                        [0.10, 0.90]])
+            try:
+                model.fit(all_feats)
+                # Ensure state index 1 always represents the DARK (higher mean) state
+                if model.means_.flatten()[0] > model.means_.flatten()[1]:
+                    for attr in ('means_', 'covars_'):
+                        arr = getattr(model, attr)
+                        arr[[0, 1]] = arr[[1, 0]]
+                    model.transmat_[:, [0, 1]] = model.transmat_[:, [1, 0]]
+                    model.transmat_[[0, 1], :] = model.transmat_[[1, 0], :]
+                    model.startprob_[[0, 1]] = model.startprob_[[1, 0]]
+
+                self._models[stype] = model
+                logger.info('Fitted HMM for "%s" on %d gaps', stype, n_gaps)
+            except Exception as exc:
+                logger.warning('HMM fit failed for "%s": %s', stype, exc)
+
+        self._fitted = bool(self._models)
+        return self
+
+    # ------------------------------------------------------------------
+    # Inference
+    # ------------------------------------------------------------------
+
+    def _score_gaps(self, time_arr: np.ndarray, ship_type: str) -> np.ndarray:
+        '''Return per-gap darkness scores in [0, 1].
+
+        Uses ``P(state=DARK | observations)`` from the fitted HMM when
+        available, otherwise falls back to the rule-based logistic scorer.
+        '''
+        feats = _gap_features(time_arr)
+        if feats.shape[0] == 0:
+            return np.array([], dtype=np.float64)
+
+        model = self._models.get(ship_type) or self._models.get('default')
+        if model is not None:
+            try:
+                _, posteriors = model.score_samples(feats)
+                return posteriors[:, self.DARK_STATE]
+            except Exception as exc:
+                logger.debug('HMM score_samples failed (%s) — using rule-based', exc)
+
+        return _rule_based_scores(time_arr, ship_type)
+
+    def annotate(self, track: dict, threshold: float = 0.5) -> dict:
+        '''Annotate a single track dict in-place with gap scores and events.
+
+        Adds the following keys to the track dict:
+
+        ``gap_durations`` (np.ndarray)
+            Seconds between consecutive pings, shape ``(n_pings - 1,)``.
+
+        ``gap_scores`` (np.ndarray)
+            Darkness probability per gap in [0, 1], same shape.
+
+        ``dark_events`` (list[DarkEvent])
+            One entry per gap whose score is >= *threshold*.
+
+        ``gap_durations`` and ``gap_scores`` are also registered in
+        ``track['dynamic']`` so downstream AISdb tools treat them
+        as per-ping arrays.
+
+        args:
+            track:     AISdb track dict.
+            threshold: Darkness score cutoff in [0, 1].
+
+        returns:
+            The annotated track dict.
+        '''
+        time = track['time']
+        if len(time) < 2:
+            track['gap_durations'] = np.array([], dtype=np.float64)
+            track['gap_scores'] = np.array([], dtype=np.float64)
+            track['dark_events'] = []
+            return track
+
+        stype = _normalise_ship_type(track)
+        gaps = np.diff(time.astype(np.float64))
+        gaps = np.maximum(gaps, 0.0)
+        scores = self._score_gaps(time, stype)
+
+        events: List[DarkEvent] = []
+        for i in np.where(scores >= threshold)[0]:
+            events.append(DarkEvent(
+                mmsi=int(track.get('mmsi', 0)),
+                start_epoch=int(time[i]),
+                end_epoch=int(time[i + 1]),
+                duration_s=float(gaps[i]),
+                lat_before=float(track['lat'][i]),
+                lon_before=float(track['lon'][i]),
+                lat_after=float(track['lat'][i + 1]),
+                lon_after=float(track['lon'][i + 1]),
+                gap_score=float(scores[i]),
+                ship_type=stype,
+            ))
+
+        track['gap_durations'] = gaps
+        track['gap_scores'] = scores
+        track['dark_events'] = events
+        track['dynamic'] = set(track.get('dynamic', set())) | {
+            'gap_durations', 'gap_scores'
+        }
+        return track
+
+    def flag_dark_gaps(
+        self,
+        tracks: Iterable[dict],
+        threshold: float = 0.5,
+    ) -> Generator[dict, None, None]:
+        '''Generator that annotates each track with dark gap information.
+
+        Drop-in pipeline filter compatible with TrackGen output::
+
+            tracks = TrackGen(rowgen, decimate=True)
+            tracks = detector.flag_dark_gaps(tracks, threshold=0.6)
+            for track in tracks:
+                for event in track['dark_events']:
+                    print(event)
+
+        args:
+            tracks:    AISdb track generator.
+            threshold: Darkness score cutoff in [0, 1].
+
+        yields:
+            Track dicts with added keys: ``gap_durations``, ``gap_scores``,
+            ``dark_events``.
+        '''
+        for track in tracks:
+            yield self.annotate(track, threshold=threshold)
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def save(self, path: str) -> None:
+        '''Save fitted models to *path* (pickle).'''
+        with open(path, 'wb') as fh:
+            pickle.dump({'models': self._models, 'fitted': self._fitted}, fh)
+        logger.info('Saved DarkVesselDetector → %s', path)
+
+    @classmethod
+    def load(cls, path: str) -> 'DarkVesselDetector':
+        '''Load a previously saved DarkVesselDetector from *path*.'''
+        with open(path, 'rb') as fh:
+            state = pickle.load(fh)
+        obj = cls()
+        obj._models = state['models']
+        obj._fitted = state['fitted']
+        logger.info('Loaded DarkVesselDetector ← %s', path)
+        return obj
+
+    def __repr__(self) -> str:
+        types = list(self._models) if self._models else ['rule-based']
+        return f'DarkVesselDetector(fitted_types={types})'
+
+
+# ---------------------------------------------------------------------------
+# Module-level pipeline function
+# ---------------------------------------------------------------------------
+
+def flag_dark_gaps(
+    tracks: Iterable[dict],
+    detector: Optional[DarkVesselDetector] = None,
+    threshold: float = 0.5,
+) -> Generator[dict, None, None]:
+    '''Annotate tracks with AIS dark gap events.
+
+    Convenience wrapper for use in TrackGen pipelines.  If no *detector* is
+    supplied a new rule-based ``DarkVesselDetector`` is created automatically
+    (no training required).
+
+    Example::
+
+        from aisdb.anomaly.dark_vessel import flag_dark_gaps
+
+        for track in flag_dark_gaps(TrackGen(rowgen, decimate=True)):
+            for event in track['dark_events']:
+                print(event)
+
+    args:
+        tracks:    AISdb track generator (TrackGen or any pipeline filter).
+        detector:  Fitted :class:`DarkVesselDetector`, or ``None`` for the
+                   rule-based fallback.
+        threshold: Darkness score cutoff in [0, 1].
+
+    yields:
+        Annotated track dicts.
+    '''
+    if detector is None:
+        detector = DarkVesselDetector()
+    yield from detector.flag_dark_gaps(tracks, threshold=threshold)

--- a/aisdb/anomaly/lstm_anomaly.py
+++ b/aisdb/anomaly/lstm_anomaly.py
@@ -1,0 +1,761 @@
+'''LSTM Autoencoder for Vessel Trajectory Anomaly Detection
+
+Detects anomalous vessel behaviour from AIS trajectory sequences using a
+sequence-to-sequence LSTM autoencoder.  The model is trained on normal
+trajectories; at inference time, tracks that cannot be reconstructed
+accurately are flagged as anomalous.
+
+Typical anomalies captured:
+- **Loitering** — slow circular motion inconsistent with the vessel's type
+- **Sudden course reversal** — sharp heading change at speed
+- **Erratic speed profile** — alternating stop/sprint behaviour
+- **Physically implausible manoeuvres** — exceeding vessel performance limits
+
+Feature vector (per-gap, location-invariant):
+  [log1p(dist_m), log1p(dt_s), sog, sin(cog), cos(cog), Δcog_norm]
+
+where:
+  - dist_m   — haversine distance to next ping (metres)
+  - dt_s     — elapsed seconds to next ping
+  - sog      — speed over ground (knots, from AIS message)
+  - cog      — course over ground (degrees, decomposed to sin/cos)
+  - Δcog_norm — normalised course change in [-1, 1]
+
+Using deltas rather than absolute coordinates makes the model
+vessel-position-agnostic and directly comparable across ocean regions.
+
+Two operating modes:
+  1. **Statistical baseline** (no training required) — Isolation Forest on
+     the feature matrix; useful for quick evaluation.
+  2. **LSTM Autoencoder** (trained) — sliding-window reconstruction; higher
+     accuracy for normal/anomalous separation.
+
+Pipeline usage::
+
+    from aisdb.anomaly.lstm_anomaly import TrajectoryAnomalyDetector, flag_anomalies
+
+    # Zero-config statistical mode
+    for track in flag_anomalies(TrackGen(rowgen, decimate=True)):
+        for event in track['anomaly_events']:
+            print(event)
+
+    # LSTM mode
+    detector = TrajectoryAnomalyDetector(mode='lstm')
+    detector.fit(training_tracks)
+    detector.save('lstm_model.pt')
+
+    detector = TrajectoryAnomalyDetector.load('lstm_model.pt')
+    for track in flag_anomalies(live_tracks, detector, threshold=0.8):
+        for event in track['anomaly_events']:
+            print(event)
+'''
+
+import logging
+import pickle
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Generator, Iterable, List, Literal, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+from sklearn.ensemble import IsolationForest
+from sklearn.preprocessing import StandardScaler
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Number of input features per timestep gap.
+N_FEATURES = 6
+
+#: Sliding window length (number of gap-steps per window).
+DEFAULT_WINDOW = 32
+
+#: Window stride during training and inference.
+DEFAULT_STRIDE = 16
+
+#: Minimum number of pings in a track to attempt anomaly scoring.
+MIN_TRACK_LENGTH = 8
+
+#: Anomaly type labels inferred from the dominant feature deviation.
+_ANOMALY_TYPES = {
+    'loitering': 'Vessel moving slowly in a small area',
+    'course_reversal': 'Abrupt change in course at speed',
+    'erratic_speed': 'Highly variable speed profile',
+    'implausible': 'Physically implausible trajectory',
+    'unknown': 'Anomalous trajectory (unclassified)',
+}
+
+
+# ---------------------------------------------------------------------------
+# Data class
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AnomalyEvent:
+    '''A detected trajectory anomaly segment.
+
+    Attributes:
+        mmsi:          Maritime Mobile Service Identity.
+        start_epoch:   Unix epoch seconds of first ping in the anomalous segment.
+        end_epoch:     Unix epoch seconds of last ping in the anomalous segment.
+        start_lat:     Latitude at start of segment.
+        start_lon:     Longitude at start of segment.
+        end_lat:       Latitude at end of segment.
+        end_lon:       Longitude at end of segment.
+        anomaly_score: Normalised score in [0, 1] (1 = most anomalous).
+        anomaly_type:  Inferred category string.
+        n_pings:       Number of pings in the segment.
+    '''
+    mmsi: int
+    start_epoch: int
+    end_epoch: int
+    start_lat: float
+    start_lon: float
+    end_lat: float
+    end_lon: float
+    anomaly_score: float
+    anomaly_type: str = 'unknown'
+    n_pings: int = 0
+
+    @property
+    def duration_s(self) -> float:
+        return float(self.end_epoch - self.start_epoch)
+
+    @property
+    def duration_hours(self) -> float:
+        return self.duration_s / 3600.0
+
+    @property
+    def start_dt(self) -> datetime:
+        return datetime.fromtimestamp(self.start_epoch, tz=timezone.utc).replace(tzinfo=None)
+
+    @property
+    def end_dt(self) -> datetime:
+        return datetime.fromtimestamp(self.end_epoch, tz=timezone.utc).replace(tzinfo=None)
+
+    def __repr__(self) -> str:
+        return (
+            f'AnomalyEvent(mmsi={self.mmsi}, type={self.anomaly_type!r}, '
+            f'start={self.start_dt.isoformat()}, '
+            f'duration={self.duration_hours:.2f}h, score={self.anomaly_score:.3f})'
+        )
+
+
+# ---------------------------------------------------------------------------
+# Feature extraction
+# ---------------------------------------------------------------------------
+
+def _extract_features(track: dict) -> np.ndarray:
+    '''Extract a location-invariant feature matrix from a track dict.
+
+    Returns shape ``(n_pings - 1, N_FEATURES)`` or an empty array if the
+    track is too short.  All features are finite-checked; rows containing
+    NaN or Inf are replaced with zeros.
+
+    Features (per gap between consecutive pings):
+      0: log1p(haversine distance in metres)
+      1: log1p(elapsed seconds)
+      2: speed over ground (knots, clipped to [0, 50])
+      3: sin(course over ground in radians)
+      4: cos(course over ground in radians)
+      5: normalised course change in [-1, 1]  (Δcog / 180)
+    '''
+    time = track['time'].astype(np.float64)
+    lon = track['lon'].astype(np.float64)
+    lat = track['lat'].astype(np.float64)
+    n = len(time)
+
+    if n < 2:
+        return np.empty((0, N_FEATURES), dtype=np.float32)
+
+    # --- haversine distances (metres) ---
+    lat_r = np.radians(lat)
+    lon_r = np.radians(lon)
+    dlat = np.diff(lat_r)
+    dlon = np.diff(lon_r)
+    a = np.sin(dlat / 2) ** 2 + np.cos(lat_r[:-1]) * np.cos(lat_r[1:]) * np.sin(dlon / 2) ** 2
+    dist_m = 2 * 6_371_088 * np.arcsin(np.sqrt(np.clip(a, 0, 1)))
+
+    # --- time deltas ---
+    dt_s = np.maximum(np.diff(time), 1.0)
+
+    # --- speed over ground (from AIS message, clipped) ---
+    sog = np.clip(track.get('sog', np.zeros(n)).astype(np.float64)[:-1], 0.0, 50.0)
+
+    # --- course over ground ---
+    cog_raw = track.get('cog', np.zeros(n)).astype(np.float64)
+    # AIS COG values > 360 indicate unavailable; replace with bearing-derived estimate
+    unavailable = cog_raw > 360.0
+    if unavailable.any():
+        bearing = np.degrees(np.arctan2(dlon, dlat)) % 360
+        # bearing has n-1 values; pad to n by repeating last
+        bearing_full = np.append(bearing, bearing[-1] if len(bearing) else 0.0)
+        cog_raw = np.where(unavailable, bearing_full, cog_raw)
+    cog_rad = np.radians(cog_raw[:-1])
+
+    # --- course change (normalised) ---
+    dcog = np.diff(cog_raw)
+    # wrap to [-180, 180]
+    dcog = ((dcog + 180) % 360) - 180
+    dcog_norm = dcog / 180.0  # in [-1, 1]
+
+    feats = np.column_stack([
+        np.log1p(dist_m),           # 0
+        np.log1p(dt_s),             # 1
+        sog,                         # 2
+        np.sin(cog_rad),             # 3
+        np.cos(cog_rad),             # 4
+        dcog_norm,                   # 5
+    ]).astype(np.float32)
+
+    # Replace non-finite values with zeros
+    feats = np.where(np.isfinite(feats), feats, 0.0)
+    return feats
+
+
+def _sliding_windows(
+    feats: np.ndarray,
+    window: int,
+    stride: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    '''Slice a feature matrix into overlapping fixed-length windows.
+
+    Returns:
+        windows: shape (n_windows, window, N_FEATURES)
+        indices: shape (n_windows,) — start index of each window in feats
+    '''
+    n = len(feats)
+    if n < window:
+        # Pad with zeros if shorter than window
+        pad = np.zeros((window - n, N_FEATURES), dtype=np.float32)
+        feats = np.vstack([feats, pad])
+        return feats[np.newaxis], np.array([0])
+
+    starts = list(range(0, n - window + 1, stride))
+    if not starts or starts[-1] + window < n:
+        starts.append(max(0, n - window))
+
+    windows = np.stack([feats[s:s + window] for s in starts])
+    return windows, np.array(starts)
+
+
+def _window_scores_to_ping_scores(
+    window_scores: np.ndarray,
+    window_starts: np.ndarray,
+    window_size: int,
+    n_gaps: int,
+) -> np.ndarray:
+    '''Map per-window anomaly scores back to per-gap scores by averaging.
+
+    Each gap index accumulates scores from all windows that cover it.
+    Returns shape (n_gaps,).
+    '''
+    accum = np.zeros(n_gaps, dtype=np.float64)
+    count = np.zeros(n_gaps, dtype=np.float64)
+    for score, start in zip(window_scores, window_starts):
+        end = min(start + window_size, n_gaps)
+        accum[start:end] += score
+        count[start:end] += 1
+    count = np.maximum(count, 1)
+    return (accum / count).astype(np.float32)
+
+
+def _infer_anomaly_type(feats: np.ndarray) -> str:
+    '''Infer the most likely anomaly category from feature deviations.'''
+    if feats.shape[0] == 0:
+        return 'unknown'
+    dist = feats[:, 0]   # log dist
+    sog = feats[:, 2]
+    dcog = feats[:, 5]
+
+    low_dist = np.median(dist) < np.log1p(50)       # median < 50 m/gap
+    low_sog = np.median(sog) < 0.5                   # knots
+    high_dcog = np.mean(np.abs(dcog)) > 0.3          # >54 deg mean change
+    high_sog_var = np.std(sog) > 3.0                 # knots std
+
+    if low_dist and low_sog:
+        return 'loitering'
+    if high_dcog and not low_sog:
+        return 'course_reversal'
+    if high_sog_var:
+        return 'erratic_speed'
+    if np.any(sog > 45):
+        return 'implausible'
+    return 'unknown'
+
+
+# ---------------------------------------------------------------------------
+# LSTM Autoencoder (PyTorch)
+# ---------------------------------------------------------------------------
+
+class _LSTMEncoder(nn.Module):
+    def __init__(self, input_size: int, hidden_size: int, n_layers: int, latent_size: int):
+        super().__init__()
+        self.lstm = nn.LSTM(input_size, hidden_size, n_layers, batch_first=True)
+        self.fc = nn.Linear(hidden_size, latent_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (batch, seq, features)
+        _, (h, _) = self.lstm(x)
+        return self.fc(h[-1])  # (batch, latent_size)
+
+
+class _LSTMDecoder(nn.Module):
+    def __init__(self, latent_size: int, hidden_size: int, n_layers: int, output_size: int, seq_len: int):
+        super().__init__()
+        self.seq_len = seq_len
+        self.fc = nn.Linear(latent_size, hidden_size)
+        self.lstm = nn.LSTM(hidden_size, hidden_size, n_layers, batch_first=True)
+        self.out = nn.Linear(hidden_size, output_size)
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        # z: (batch, latent_size) → repeat across time → reconstruct
+        h = self.fc(z).unsqueeze(1).repeat(1, self.seq_len, 1)
+        out, _ = self.lstm(h)
+        return self.out(out)  # (batch, seq, output_size)
+
+
+class _LSTMAutoencoder(nn.Module):
+    '''Sequence-to-sequence LSTM autoencoder for trajectory reconstruction.'''
+
+    def __init__(
+        self,
+        input_size: int = N_FEATURES,
+        hidden_size: int = 64,
+        latent_size: int = 16,
+        n_layers: int = 2,
+        seq_len: int = DEFAULT_WINDOW,
+    ):
+        super().__init__()
+        self.encoder = _LSTMEncoder(input_size, hidden_size, n_layers, latent_size)
+        self.decoder = _LSTMDecoder(latent_size, hidden_size, n_layers, input_size, seq_len)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        z = self.encoder(x)
+        return self.decoder(z)
+
+    def reconstruction_error(self, x: torch.Tensor) -> torch.Tensor:
+        '''Return mean squared error per sample in the batch.'''
+        x_hat = self.forward(x)
+        return ((x - x_hat) ** 2).mean(dim=(1, 2))   # (batch,)
+
+
+# ---------------------------------------------------------------------------
+# Core detector
+# ---------------------------------------------------------------------------
+
+class TrajectoryAnomalyDetector:
+    '''Detects anomalous AIS vessel trajectories using an LSTM autoencoder
+    or Isolation Forest baseline.
+
+    Two modes:
+
+    ``'statistical'`` (default, no training required)
+        Fits an Isolation Forest on extracted feature vectors.
+        Works immediately without any track data.
+
+    ``'lstm'``
+        Trains a sequence-to-sequence LSTM autoencoder on sliding windows
+        of normal trajectories.  Anomaly score = reconstruction error,
+        normalised to [0, 1] against training-set statistics.
+
+    Example — statistical mode::
+
+        detector = TrajectoryAnomalyDetector()          # mode='statistical'
+        for track in detector.flag_anomalies(tracks):
+            for ev in track['anomaly_events']:
+                print(ev)
+
+    Example — LSTM mode::
+
+        detector = TrajectoryAnomalyDetector(mode='lstm')
+        detector.fit(training_tracks)
+        detector.save('model.pt')
+        ...
+        detector = TrajectoryAnomalyDetector.load('model.pt')
+        for track in detector.flag_anomalies(live_tracks, threshold=0.75):
+            ...
+    '''
+
+    def __init__(
+        self,
+        mode: Literal['statistical', 'lstm'] = 'statistical',
+        window_size: int = DEFAULT_WINDOW,
+        stride: int = DEFAULT_STRIDE,
+        hidden_size: int = 64,
+        latent_size: int = 16,
+        n_layers: int = 2,
+    ) -> None:
+        self.mode = mode
+        self.window_size = window_size
+        self.stride = stride
+
+        # Shared
+        self._scaler = StandardScaler()
+        self._fitted = False
+        self._threshold_95: float = 0.5   # 95th-pct training error (lstm) or score (iso)
+
+        # Statistical mode
+        self._iforest: Optional[IsolationForest] = None
+
+        # LSTM mode
+        self._lstm: Optional[_LSTMAutoencoder] = None
+        self._lstm_config: Dict = dict(
+            hidden_size=hidden_size,
+            latent_size=latent_size,
+            n_layers=n_layers,
+            seq_len=window_size,
+        )
+
+    # ------------------------------------------------------------------
+    # Training
+    # ------------------------------------------------------------------
+
+    def fit(
+        self,
+        tracks: Iterable[dict],
+        epochs: int = 20,
+        batch_size: int = 64,
+        lr: float = 1e-3,
+        contamination: float = 0.05,
+    ) -> 'TrajectoryAnomalyDetector':
+        '''Fit the detector on a collection of (assumed-normal) tracks.
+
+        For ``mode='statistical'`` trains an Isolation Forest.
+        For ``mode='lstm'`` trains the LSTM autoencoder.
+
+        args:
+            tracks:        Iterable of AISdb track dicts.
+            epochs:        (LSTM only) Training epochs.
+            batch_size:    (LSTM only) Mini-batch size.
+            lr:            (LSTM only) Adam learning rate.
+            contamination: (statistical only) Expected fraction of outliers
+                           in the training data (passed to IsolationForest).
+
+        returns:
+            self — allows method chaining.
+        '''
+        all_feats: List[np.ndarray] = []
+        all_windows: List[np.ndarray] = []
+
+        for track in tracks:
+            feats = _extract_features(track)
+            if feats.shape[0] < MIN_TRACK_LENGTH - 1:
+                continue
+            all_feats.append(feats)
+            if self.mode == 'lstm':
+                wins, _ = _sliding_windows(feats, self.window_size, self.stride)
+                all_windows.append(wins)
+
+        if not all_feats:
+            logger.warning('No usable tracks for fitting — detector will use defaults.')
+            return self
+
+        # Fit scaler on raw per-gap features
+        flat = np.vstack(all_feats)
+        self._scaler.fit(flat)
+
+        if self.mode == 'statistical':
+            self._fit_statistical(flat, contamination)
+        else:
+            self._fit_lstm(all_windows, epochs, batch_size, lr)
+
+        self._fitted = True
+        return self
+
+    def _fit_statistical(self, flat_feats: np.ndarray, contamination: float) -> None:
+        scaled = self._scaler.transform(flat_feats)
+        self._iforest = IsolationForest(
+            n_estimators=200,
+            contamination=contamination,
+            random_state=42,
+            n_jobs=-1,
+        )
+        self._iforest.fit(scaled)
+        # Calibrate threshold: raw scores from IsolationForest are negative
+        # (more negative = more anomalous); convert to [0,1] anomaly probability
+        raw = -self._iforest.score_samples(scaled)   # positive = anomalous
+        self._threshold_95 = float(np.percentile(raw, 95))
+        logger.info('Fitted IsolationForest on %d gap-features', flat_feats.shape[0])
+
+    def _fit_lstm(
+        self,
+        all_windows: List[np.ndarray],
+        epochs: int,
+        batch_size: int,
+        lr: float,
+    ) -> None:
+        if not all_windows:
+            logger.warning('No windows to train LSTM on.')
+            return
+
+        # Stack and scale windows
+        raw = np.vstack(all_windows).astype(np.float32)          # (N, T, F)
+        N, T, F = raw.shape
+        flat = raw.reshape(-1, F)
+        flat_scaled = self._scaler.transform(flat).astype(np.float32)
+        data = torch.tensor(flat_scaled.reshape(N, T, F))
+
+        self._lstm = _LSTMAutoencoder(**self._lstm_config)
+        optimiser = torch.optim.Adam(self._lstm.parameters(), lr=lr)
+        criterion = nn.MSELoss()
+
+        self._lstm.train()
+        for epoch in range(epochs):
+            perm = torch.randperm(N)
+            epoch_loss = 0.0
+            for i in range(0, N, batch_size):
+                batch = data[perm[i:i + batch_size]]
+                optimiser.zero_grad()
+                recon = self._lstm(batch)
+                loss = criterion(recon, batch)
+                loss.backward()
+                optimiser.step()
+                epoch_loss += loss.item() * len(batch)
+            if (epoch + 1) % 5 == 0 or epoch == 0:
+                logger.info('LSTM epoch %d/%d — loss %.4f', epoch + 1, epochs, epoch_loss / N)
+
+        # Calibrate threshold on training reconstruction errors
+        self._lstm.eval()
+        with torch.no_grad():
+            errors = self._lstm.reconstruction_error(data).numpy()
+        self._threshold_95 = float(np.percentile(errors, 95))
+        logger.info('LSTM fitted. 95th-pct training error: %.4f', self._threshold_95)
+
+    # ------------------------------------------------------------------
+    # Inference helpers
+    # ------------------------------------------------------------------
+
+    def _scale(self, feats: np.ndarray) -> np.ndarray:
+        '''Scale features, fitting the scaler on-the-fly if not yet fitted.'''
+        from sklearn.exceptions import NotFittedError
+        try:
+            return self._scaler.transform(feats)
+        except NotFittedError:
+            # No training data seen yet — fit on the current track as a proxy
+            self._scaler.fit(feats)
+            return self._scaler.transform(feats)
+
+    def _score_track_statistical(self, feats: np.ndarray) -> np.ndarray:
+        '''Return per-gap anomaly scores in [0, 1] using Isolation Forest.'''
+        scaled = self._scale(feats)
+        if self._iforest is not None:
+            raw = -self._iforest.score_samples(scaled)
+        else:
+            # Unfitted: use z-score magnitude as proxy
+            raw = np.linalg.norm(scaled, axis=1)
+        # Normalise to [0, 1] via sigmoid centred at 95th pct
+        denom = max(self._threshold_95, 1e-6)
+        return (1.0 / (1.0 + np.exp(-(raw - denom) / denom))).astype(np.float32)
+
+    def _score_track_lstm(self, feats: np.ndarray) -> np.ndarray:
+        '''Return per-gap anomaly scores in [0, 1] using LSTM reconstruction.'''
+        if self._lstm is None:
+            return self._score_track_statistical(feats)
+
+        scaled = self._scale(feats).astype(np.float32)
+        windows, starts = _sliding_windows(scaled, self.window_size, self.stride)
+        tensor = torch.tensor(windows)
+
+        self._lstm.eval()
+        with torch.no_grad():
+            errors = self._lstm.reconstruction_error(tensor).numpy()
+
+        ping_errors = _window_scores_to_ping_scores(errors, starts, self.window_size, len(feats))
+        denom = max(self._threshold_95, 1e-6)
+        return (1.0 / (1.0 + np.exp(-(ping_errors - denom) / denom))).astype(np.float32)
+
+    def _score_track(self, feats: np.ndarray) -> np.ndarray:
+        if self.mode == 'lstm':
+            return self._score_track_lstm(feats)
+        return self._score_track_statistical(feats)
+
+    # ------------------------------------------------------------------
+    # Annotation
+    # ------------------------------------------------------------------
+
+    def annotate(self, track: dict, threshold: float = 0.5) -> dict:
+        '''Annotate a single track dict with trajectory anomaly scores.
+
+        Adds the following keys:
+
+        ``anomaly_scores`` (np.ndarray)
+            Per-gap anomaly score in [0, 1], shape ``(n_pings - 1,)``.
+
+        ``anomaly_events`` (list[AnomalyEvent])
+            Contiguous runs of gaps whose score >= *threshold*.
+
+        ``anomaly_scores`` is registered in ``track['dynamic']``.
+
+        args:
+            track:     AISdb track dict.
+            threshold: Anomaly score cutoff in [0, 1].
+
+        returns:
+            The annotated track dict.
+        '''
+        feats = _extract_features(track)
+
+        if feats.shape[0] == 0:
+            track['anomaly_scores'] = np.array([], dtype=np.float32)
+            track['anomaly_events'] = []
+            return track
+
+        scores = self._score_track(feats)
+        track['anomaly_scores'] = scores
+        track['dynamic'] = set(track.get('dynamic', set())) | {'anomaly_scores'}
+
+        # Build contiguous anomaly events
+        events: List[AnomalyEvent] = []
+        time = track['time']
+        lat = track['lat']
+        lon = track['lon']
+        above = scores >= threshold
+
+        i = 0
+        while i < len(above):
+            if not above[i]:
+                i += 1
+                continue
+            # Start of a contiguous anomalous run
+            j = i
+            while j < len(above) and above[j]:
+                j += 1
+            # Segment: gap indices [i, j) → ping indices [i, j+1)
+            seg_start_ping = i
+            seg_end_ping = min(j, len(time) - 1)
+            seg_feats = feats[i:j]
+            events.append(AnomalyEvent(
+                mmsi=int(track.get('mmsi', 0)),
+                start_epoch=int(time[seg_start_ping]),
+                end_epoch=int(time[seg_end_ping]),
+                start_lat=float(lat[seg_start_ping]),
+                start_lon=float(lon[seg_start_ping]),
+                end_lat=float(lat[seg_end_ping]),
+                end_lon=float(lon[seg_end_ping]),
+                anomaly_score=float(scores[i:j].max()),
+                anomaly_type=_infer_anomaly_type(seg_feats),
+                n_pings=seg_end_ping - seg_start_ping + 1,
+            ))
+            i = j
+
+        track['anomaly_events'] = events
+        return track
+
+    def flag_anomalies(
+        self,
+        tracks: Iterable[dict],
+        threshold: float = 0.5,
+    ) -> Generator[dict, None, None]:
+        '''Generator that annotates each track with trajectory anomaly info.
+
+        Drop-in pipeline filter::
+
+            tracks = TrackGen(rowgen, decimate=True)
+            for track in detector.flag_anomalies(tracks, threshold=0.7):
+                for event in track['anomaly_events']:
+                    print(event)
+
+        args:
+            tracks:    AISdb track generator.
+            threshold: Anomaly score cutoff in [0, 1].
+
+        yields:
+            Track dicts with ``anomaly_scores`` and ``anomaly_events`` added.
+        '''
+        for track in tracks:
+            yield self.annotate(track, threshold=threshold)
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def save(self, path: str) -> None:
+        '''Save the fitted detector to *path*.
+
+        For LSTM mode the PyTorch model state dict is embedded in the
+        pickle alongside the scaler and metadata.
+        '''
+        state = {
+            'mode': self.mode,
+            'window_size': self.window_size,
+            'stride': self.stride,
+            'lstm_config': self._lstm_config,
+            'scaler': self._scaler,
+            'threshold_95': self._threshold_95,
+            'fitted': self._fitted,
+            'iforest': self._iforest,
+            'lstm_state': self._lstm.state_dict() if self._lstm is not None else None,
+        }
+        with open(path, 'wb') as fh:
+            pickle.dump(state, fh)
+        logger.info('Saved TrajectoryAnomalyDetector → %s', path)
+
+    @classmethod
+    def load(cls, path: str) -> 'TrajectoryAnomalyDetector':
+        '''Load a previously saved TrajectoryAnomalyDetector from *path*.'''
+        with open(path, 'rb') as fh:
+            state = pickle.load(fh)
+        cfg = state['lstm_config']
+        obj = cls(
+            mode=state['mode'],
+            window_size=state['window_size'],
+            stride=state['stride'],
+            hidden_size=cfg['hidden_size'],
+            latent_size=cfg['latent_size'],
+            n_layers=cfg['n_layers'],
+        )
+        obj._scaler = state['scaler']
+        obj._threshold_95 = state['threshold_95']
+        obj._fitted = state['fitted']
+        obj._iforest = state['iforest']
+        if state['lstm_state'] is not None:
+            obj._lstm = _LSTMAutoencoder(**state['lstm_config'])
+            obj._lstm.load_state_dict(state['lstm_state'])
+            obj._lstm.eval()
+        logger.info('Loaded TrajectoryAnomalyDetector ← %s', path)
+        return obj
+
+    def __repr__(self) -> str:
+        status = 'fitted' if self._fitted else 'unfitted'
+        return f'TrajectoryAnomalyDetector(mode={self.mode!r}, {status})'
+
+
+# ---------------------------------------------------------------------------
+# Module-level pipeline function
+# ---------------------------------------------------------------------------
+
+def flag_anomalies(
+    tracks: Iterable[dict],
+    detector: Optional[TrajectoryAnomalyDetector] = None,
+    threshold: float = 0.5,
+) -> Generator[dict, None, None]:
+    '''Annotate tracks with trajectory anomaly events.
+
+    Convenience wrapper for TrackGen pipelines.  If no *detector* is given
+    a default statistical (Isolation Forest) detector is created.
+
+    Example::
+
+        from aisdb.anomaly.lstm_anomaly import flag_anomalies
+
+        for track in flag_anomalies(TrackGen(rowgen, decimate=True)):
+            for event in track['anomaly_events']:
+                print(event)
+
+    args:
+        tracks:    AISdb track generator (TrackGen or any filter).
+        detector:  Fitted :class:`TrajectoryAnomalyDetector`, or ``None``
+                   to use default statistical mode.
+        threshold: Anomaly score cutoff in [0, 1].
+
+    yields:
+        Annotated track dicts.
+    '''
+    if detector is None:
+        detector = TrajectoryAnomalyDetector(mode='statistical')
+    yield from detector.flag_anomalies(tracks, threshold=threshold)

--- a/aisdb/anomaly/spoof_detect.py
+++ b/aisdb/anomaly/spoof_detect.py
@@ -1,0 +1,617 @@
+'''AIS Spoofing Detection — Physics-Based Signal Integrity Analysis
+
+Detects AIS message spoofing by cross-checking transmitted positional data
+against physical and kinematic constraints derived from the VHF radio
+propagation model and maritime vessel performance limits.
+
+Background
+----------
+AIS broadcasts on VHF channels 87B (161.975 MHz) and 88B (162.025 MHz)
+using TDMA.  Because the transmission medium is well-understood, several
+consistency checks are possible without extra sensors:
+
+Kinematic impossibility
+    The haversine distance between consecutive positions divided by the
+    elapsed time gives an implied speed.  If this exceeds the physical
+    performance envelope for the vessel type, the position is suspect.
+
+SOG/COG inconsistency
+    AIS messages carry both reported Speed Over Ground and Course Over
+    Ground.  A spoofer injecting a false position without updating the
+    kinematic fields will leave detectable mismatches between the
+    reported values and what can be derived from consecutive positions.
+
+Transmission interval injection
+    The ITU-R M.1371 standard defines reporting intervals by vessel class
+    and navigation status.  Sub-second intervals or systematically
+    shorter-than-expected gaps indicate software-injected messages.
+
+MMSI conflict
+    The same MMSI appearing at two physically-separated locations within
+    a time window too short to allow transit between them indicates either
+    spoofing of one transmitter or MMSI duplication.
+
+Four per-ping indicator scores are computed, each in [0, 1]:
+
+    ``kinematic``      — implied speed vs vessel-type envelope
+    ``sog_delta``      — |reported SOG − computed SOG|
+    ``cog_delta``      — angular deviation between reported COG and bearing
+    ``interval``       — transmission interval too short or irregular
+
+A composite score is the weighted mean; individual SpoofEvent objects
+identify the dominant indicator for each flagged segment.
+
+Usage::
+
+    from aisdb.anomaly.spoof_detect import SpoofingDetector, flag_spoofing
+
+    # Per-track spoofing checks (no training required)
+    for track in flag_spoofing(TrackGen(rowgen, decimate=True)):
+        for event in track['spoof_events']:
+            print(event)
+
+    # Cross-track MMSI conflict detection
+    detector = SpoofingDetector()
+    for track in detector.check_mmsi_conflicts(tracks):
+        for event in track['spoof_events']:
+            if event.spoof_type == 'mmsi_conflict':
+                print(event)
+'''
+
+import logging
+import pickle
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Generator, Iterable, List, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Physical constants and vessel-type performance envelopes
+# ---------------------------------------------------------------------------
+
+#: Maximum physically credible speed (knots) per vessel type.
+#: Values derived from Jane's Fighting Ships, IMO vessel class data, and
+#: AIS spoofing literature (Iphar et al. 2015, Harati-Mokhtari et al. 2007).
+MAX_SPEED_KNOTS: Dict[str, float] = {
+    'fishing':    15.0,
+    'tanker':     18.0,
+    'cargo':      25.0,
+    'passenger':  35.0,
+    'tug':        14.0,
+    'default':    50.0,   # conservative upper bound for unknown type
+}
+
+#: Nominal AIS reporting interval (seconds) per vessel type, per ITU-R M.1371.
+NOMINAL_INTERVAL_S: Dict[str, float] = {
+    'fishing':   180.0,
+    'tanker':     10.0,
+    'cargo':      10.0,
+    'passenger':   5.0,
+    'tug':        10.0,
+    'default':    10.0,
+}
+
+#: SOG discrepancy (knots) above which the mismatch is considered suspicious.
+SOG_TOLERANCE_KN: float = 5.0
+
+#: COG angular discrepancy (degrees) above which the mismatch is flagged.
+COG_TOLERANCE_DEG: float = 30.0
+
+#: Transmission interval shorter than this (seconds) is flagged as injected.
+MIN_CREDIBLE_INTERVAL_S: float = 2.0
+
+#: MMSI conflict window: two tracks with same MMSI whose inter-position
+#: speed exceeds this are flagged as conflicting.
+MMSI_CONFLICT_SPEED_KN: float = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Data class
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SpoofEvent:
+    '''A detected AIS spoofing indicator at a specific position.
+
+    Attributes:
+        mmsi:              Maritime Mobile Service Identity.
+        epoch:             Unix epoch seconds of the suspicious ping.
+        lat:               Latitude at the suspicious ping.
+        lon:               Longitude at the suspicious ping.
+        spoof_score:       Composite indicator score in [0, 1].
+        spoof_type:        Dominant indicator type (see module docstring).
+        computed_speed_kn: Haversine-derived speed leading into this ping.
+        reported_speed_kn: SOG from the AIS message.
+        computed_bearing:  Bearing from previous ping (degrees, 0–360).
+        reported_cog:      COG from the AIS message (degrees).
+        details:           Human-readable description of the indicator.
+    '''
+    mmsi: int
+    epoch: int
+    lat: float
+    lon: float
+    spoof_score: float
+    spoof_type: str = 'unknown'
+    computed_speed_kn: float = 0.0
+    reported_speed_kn: float = 0.0
+    computed_bearing: float = 0.0
+    reported_cog: float = 0.0
+    details: str = ''
+
+    @property
+    def dt(self) -> datetime:
+        return datetime.fromtimestamp(self.epoch, tz=timezone.utc).replace(tzinfo=None)
+
+    def __repr__(self) -> str:
+        return (
+            f'SpoofEvent(mmsi={self.mmsi}, type={self.spoof_type!r}, '
+            f'at={self.dt.isoformat()}, score={self.spoof_score:.3f}, '
+            f'computed={self.computed_speed_kn:.1f}kn '
+            f'reported={self.reported_speed_kn:.1f}kn)'
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _normalise_ship_type(track: dict) -> str:
+    raw = track.get('ship_type_txt', '') or track.get('ship_type', '') or ''
+    raw = str(raw).lower()
+    for key in MAX_SPEED_KNOTS:
+        if key in raw:
+            return key
+    return 'default'
+
+
+def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    '''Haversine distance in metres between two (lat, lon) pairs.'''
+    R = 6_371_088.0
+    phi1, phi2 = np.radians(lat1), np.radians(lat2)
+    dphi = np.radians(lat2 - lat1)
+    dlam = np.radians(lon2 - lon1)
+    a = np.sin(dphi / 2) ** 2 + np.cos(phi1) * np.cos(phi2) * np.sin(dlam / 2) ** 2
+    return 2 * R * np.arcsin(np.sqrt(np.clip(a, 0, 1)))
+
+
+def _bearing_deg(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    '''True bearing (0–360°) from point 1 to point 2.'''
+    lat1r, lat2r = np.radians(lat1), np.radians(lat2)
+    dlam = np.radians(lon2 - lon1)
+    x = np.sin(dlam) * np.cos(lat2r)
+    y = np.cos(lat1r) * np.sin(lat2r) - np.sin(lat1r) * np.cos(lat2r) * np.cos(dlam)
+    return (np.degrees(np.arctan2(x, y)) + 360) % 360
+
+
+def _angular_diff_deg(a: float, b: float) -> float:
+    '''Smallest absolute angular difference between two bearings (0–180°).'''
+    diff = abs(a - b) % 360
+    return min(diff, 360 - diff)
+
+
+def _sigmoid(x: float, centre: float, width: float) -> float:
+    '''Logistic sigmoid in [0,1] centred at *centre* with half-width *width*.'''
+    return float(1.0 / (1.0 + np.exp(-((x - centre) / max(width, 1e-9)))))
+
+
+# ---------------------------------------------------------------------------
+# Per-ping indicator scoring
+# ---------------------------------------------------------------------------
+
+def _kinematic_score(
+    computed_kn: float,
+    max_kn: float,
+) -> float:
+    '''Score how impossible the implied speed is for this vessel type.
+
+    0.0 → speed within envelope
+    1.0 → speed far exceeds physical limit
+
+    Uses a sigmoid ramp centred at *max_kn* with half-width 0.3 × max_kn
+    so the score rises sharply once the threshold is breached.
+    '''
+    return _sigmoid(computed_kn, max_kn, max_kn * 0.3)
+
+
+def _sog_delta_score(computed_kn: float, reported_kn: float) -> float:
+    '''Score for SOG inconsistency between computed and reported values.
+
+    Unavailable SOG values (> 102.2 knots per AIS spec) are ignored.
+    '''
+    if reported_kn > 102.0:   # AIS "not available" sentinel
+        return 0.0
+    delta = abs(computed_kn - reported_kn)
+    return _sigmoid(delta, SOG_TOLERANCE_KN, SOG_TOLERANCE_KN * 0.4)
+
+
+def _cog_delta_score(computed_bearing: float, reported_cog: float) -> float:
+    '''Score for COG inconsistency between computed bearing and reported COG.
+
+    Unavailable COG values (≥ 360° per AIS spec) are ignored.
+    Only meaningful when the vessel is actually moving (computed_speed > 0.5 kn);
+    a stationary vessel has undefined bearing.
+    '''
+    if reported_cog >= 360.0:  # AIS "not available" sentinel
+        return 0.0
+    diff = _angular_diff_deg(computed_bearing, reported_cog)
+    return _sigmoid(diff, COG_TOLERANCE_DEG, COG_TOLERANCE_DEG * 0.4)
+
+
+def _interval_score(dt_s: float, nominal_s: float) -> float:
+    '''Score for suspiciously short transmission intervals.
+
+    Sub-second intervals are almost certainly injected messages.
+    Intervals below MIN_CREDIBLE_INTERVAL_S score highly regardless of type.
+    '''
+    if dt_s < MIN_CREDIBLE_INTERVAL_S:
+        return 1.0
+    # Also flag intervals that are dramatically shorter than nominal
+    ratio = nominal_s / max(dt_s, 0.1)
+    if ratio > 10:              # more than 10× faster than expected
+        return _sigmoid(ratio, 10.0, 3.0)
+    return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Core detector
+# ---------------------------------------------------------------------------
+
+class SpoofingDetector:
+    '''Detects AIS message spoofing using physics-based indicator scoring.
+
+    No training is required.  All checks are based on the physical
+    constraints of VHF radio propagation, maritime vessel performance,
+    and the ITU-R M.1371 AIS standard.
+
+    Four per-ping indicators are computed:
+
+    ``kinematic``
+        Implied speed between consecutive positions vs vessel-type envelope.
+        A vessel that "teleports" will always score 1.0 here.
+
+    ``sog_delta``
+        Absolute difference between AIS-reported SOG and haversine-derived
+        speed.  A spoofer injecting a false position without updating the
+        kinematic fields leaves a detectable mismatch.
+
+    ``cog_delta``
+        Angular deviation between AIS-reported COG and the true bearing
+        from the previous position.  Flagged when > 30° and vessel is
+        moving.
+
+    ``interval``
+        Transmission interval shorter than MIN_CREDIBLE_INTERVAL_S (2 s)
+        or >10× faster than the nominal rate for the vessel type, indicating
+        software-injected messages.
+
+    Composite score = weighted mean of all four indicators.
+
+    Example::
+
+        detector = SpoofingDetector()
+
+        # Per-track annotation
+        for track in detector.flag_spoofing(tracks, threshold=0.6):
+            for event in track['spoof_events']:
+                print(event)
+
+        # Cross-track MMSI conflict detection
+        for track in detector.check_mmsi_conflicts(tracks):
+            conflicts = [e for e in track['spoof_events']
+                         if e.spoof_type == 'mmsi_conflict']
+    '''
+
+    #: Weights for the four indicators in the composite score.
+    WEIGHTS = {
+        'kinematic': 0.40,
+        'sog_delta': 0.25,
+        'cog_delta': 0.20,
+        'interval':  0.15,
+    }
+
+    def __init__(self) -> None:
+        # Rolling per-MMSI last-seen record for MMSI conflict detection.
+        # Maps mmsi → (epoch, lat, lon)
+        self._mmsi_registry: Dict[int, Tuple[int, float, float]] = {}
+
+    # ------------------------------------------------------------------
+    # Per-track scoring
+    # ------------------------------------------------------------------
+
+    def score_track(self, track: dict) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        '''Compute per-ping indicator scores for a single track.
+
+        Returns a tuple of five numpy arrays, each of shape ``(n_pings - 1,)``:
+            (composite, kinematic, sog_delta, cog_delta, interval)
+
+        All values are in [0, 1].  Returns empty arrays for single-ping tracks.
+        '''
+        time = track['time'].astype(np.float64)
+        lat = track['lat'].astype(np.float64)
+        lon = track['lon'].astype(np.float64)
+        sog_rep = track.get('sog', np.zeros(len(time))).astype(np.float64)
+        cog_rep = track.get('cog', np.full(len(time), 511.0)).astype(np.float64)
+        n = len(time)
+
+        empty = np.array([], dtype=np.float32)
+        if n < 2:
+            return empty, empty, empty, empty, empty
+
+        stype = _normalise_ship_type(track)
+        max_kn = MAX_SPEED_KNOTS[stype]
+        nominal_s = NOMINAL_INTERVAL_S[stype]
+
+        kin_scores = np.zeros(n - 1, dtype=np.float32)
+        sog_scores = np.zeros(n - 1, dtype=np.float32)
+        cog_scores = np.zeros(n - 1, dtype=np.float32)
+        int_scores = np.zeros(n - 1, dtype=np.float32)
+
+        for i in range(n - 1):
+            dt_s = max(time[i + 1] - time[i], 0.001)
+            dist_m = _haversine_m(lat[i], lon[i], lat[i + 1], lon[i + 1])
+            comp_kn = (dist_m / dt_s) * 1.94384   # m/s → knots
+
+            bearing = _bearing_deg(lat[i], lon[i], lat[i + 1], lon[i + 1])
+
+            kin_scores[i] = _kinematic_score(comp_kn, max_kn)
+            # SOG and COG checks are only meaningful when vessel is moving
+            if comp_kn > 0.2:
+                sog_scores[i] = _sog_delta_score(comp_kn, float(sog_rep[i + 1]))
+                cog_scores[i] = _cog_delta_score(bearing, float(cog_rep[i + 1]))
+            int_scores[i] = _interval_score(dt_s, nominal_s)
+
+        w = self.WEIGHTS
+        composite = (
+            w['kinematic'] * kin_scores
+            + w['sog_delta'] * sog_scores
+            + w['cog_delta'] * cog_scores
+            + w['interval'] * int_scores
+        ).astype(np.float32)
+
+        return composite, kin_scores, sog_scores, cog_scores, int_scores
+
+    def annotate(self, track: dict, threshold: float = 0.5) -> dict:
+        '''Annotate a single track dict with spoofing indicator scores.
+
+        Adds the following keys:
+
+        ``spoof_scores`` (np.ndarray)
+            Composite per-ping spoofing score in [0, 1], shape ``(n-1,)``.
+
+        ``spoof_kinematic``, ``spoof_sog``, ``spoof_cog``, ``spoof_interval``
+            Individual indicator arrays, same shape.
+
+        ``spoof_events`` (list[SpoofEvent])
+            One entry per ping whose composite score ≥ *threshold*.
+
+        All score arrays are registered in ``track['dynamic']``.
+
+        args:
+            track:     AISdb track dict.
+            threshold: Composite score cutoff in [0, 1].
+
+        returns:
+            The annotated track dict.
+        '''
+        composite, kin, sog_d, cog_d, intv = self.score_track(track)
+
+        track['spoof_scores'] = composite
+        track['spoof_kinematic'] = kin
+        track['spoof_sog'] = sog_d
+        track['spoof_cog'] = cog_d
+        track['spoof_interval'] = intv
+        track['dynamic'] = set(track.get('dynamic', set())) | {
+            'spoof_scores', 'spoof_kinematic', 'spoof_sog', 'spoof_cog', 'spoof_interval',
+        }
+
+        events: List[SpoofEvent] = []
+        if len(composite) == 0:
+            track['spoof_events'] = events
+            return track
+
+        time = track['time']
+        lat = track['lat'].astype(np.float64)
+        lon = track['lon'].astype(np.float64)
+        sog_rep = track.get('sog', np.zeros(len(time))).astype(np.float64)
+        cog_rep = track.get('cog', np.full(len(time), 511.0)).astype(np.float64)
+
+        for i in np.where(composite >= threshold)[0]:
+            dt_s = max(float(time[i + 1]) - float(time[i]), 0.001)
+            dist_m = _haversine_m(lat[i], lon[i], lat[i + 1], lon[i + 1])
+            comp_kn = (dist_m / dt_s) * 1.94384
+            bearing = _bearing_deg(lat[i], lon[i], lat[i + 1], lon[i + 1])
+
+            # Identify the dominant indicator for this ping
+            indicators = {
+                'kinematic': float(kin[i]),
+                'sog_delta': float(sog_d[i]),
+                'cog_delta': float(cog_d[i]),
+                'interval':  float(intv[i]),
+            }
+            dominant = max(indicators, key=indicators.get)
+
+            details_map = {
+                'kinematic': f'implied speed {comp_kn:.1f} kn exceeds envelope',
+                'sog_delta': f'SOG mismatch: computed={comp_kn:.1f} reported={sog_rep[i+1]:.1f} kn',
+                'cog_delta': f'COG mismatch: bearing={bearing:.0f}° reported={cog_rep[i+1]:.0f}°',
+                'interval':  f'interval {dt_s:.1f}s below credible minimum',
+            }
+
+            events.append(SpoofEvent(
+                mmsi=int(track.get('mmsi', 0)),
+                epoch=int(time[i + 1]),
+                lat=float(lat[i + 1]),
+                lon=float(lon[i + 1]),
+                spoof_score=float(composite[i]),
+                spoof_type=dominant,
+                computed_speed_kn=comp_kn,
+                reported_speed_kn=float(sog_rep[i + 1]),
+                computed_bearing=bearing,
+                reported_cog=float(cog_rep[i + 1]),
+                details=details_map[dominant],
+            ))
+
+        track['spoof_events'] = events
+        return track
+
+    def flag_spoofing(
+        self,
+        tracks: Iterable[dict],
+        threshold: float = 0.5,
+    ) -> Generator[dict, None, None]:
+        '''Generator that annotates each track with spoofing indicator scores.
+
+        Drop-in pipeline filter::
+
+            for track in detector.flag_spoofing(TrackGen(rowgen), threshold=0.6):
+                for event in track['spoof_events']:
+                    print(event)
+
+        args:
+            tracks:    AISdb track generator.
+            threshold: Composite score cutoff in [0, 1].
+
+        yields:
+            Track dicts with ``spoof_scores`` and ``spoof_events`` added.
+        '''
+        for track in tracks:
+            yield self.annotate(track, threshold=threshold)
+
+    # ------------------------------------------------------------------
+    # Cross-track MMSI conflict detection
+    # ------------------------------------------------------------------
+
+    def check_mmsi_conflicts(
+        self,
+        tracks: Iterable[dict],
+        threshold: float = 0.5,
+    ) -> Generator[dict, None, None]:
+        '''Generator that annotates tracks AND checks for MMSI conflicts.
+
+        Maintains a rolling registry of the most recent position seen for
+        each MMSI.  When a new track for the same MMSI arrives and the
+        implied transit speed from the last known position exceeds
+        ``MMSI_CONFLICT_SPEED_KN``, a ``SpoofEvent`` of type
+        ``'mmsi_conflict'`` is prepended to ``track['spoof_events']``.
+
+        This catches the most common AIS spoofing attack: a vessel that
+        broadcasts a false MMSI to impersonate another ship (or to hide
+        its own identity), resulting in the same MMSI appearing
+        simultaneously in two physically-separated locations.
+
+        args:
+            tracks:    AISdb track generator.
+            threshold: Composite kinematic score cutoff for per-ping events.
+
+        yields:
+            Annotated track dicts, possibly with ``mmsi_conflict`` events.
+        '''
+        for track in self.flag_spoofing(tracks, threshold=threshold):
+            mmsi = int(track.get('mmsi', 0))
+            time = track['time']
+            lat = track['lat'].astype(np.float64)
+            lon = track['lon'].astype(np.float64)
+
+            if mmsi and len(time) >= 1:
+                first_epoch = int(time[0])
+                first_lat = float(lat[0])
+                first_lon = float(lon[0])
+
+                if mmsi in self._mmsi_registry:
+                    prev_epoch, prev_lat, prev_lon = self._mmsi_registry[mmsi]
+                    dt_s = max(abs(first_epoch - prev_epoch), 1.0)
+                    dist_m = _haversine_m(prev_lat, prev_lon, first_lat, first_lon)
+                    implied_kn = (dist_m / dt_s) * 1.94384
+
+                    if implied_kn > MMSI_CONFLICT_SPEED_KN:
+                        conflict = SpoofEvent(
+                            mmsi=mmsi,
+                            epoch=first_epoch,
+                            lat=first_lat,
+                            lon=first_lon,
+                            spoof_score=min(1.0, implied_kn / MMSI_CONFLICT_SPEED_KN),
+                            spoof_type='mmsi_conflict',
+                            computed_speed_kn=implied_kn,
+                            details=(
+                                f'MMSI {mmsi} implies {implied_kn:.0f} kn transit '
+                                f'from last known position — likely duplicate MMSI '
+                                f'or position spoofing'
+                            ),
+                        )
+                        track['spoof_events'].insert(0, conflict)
+                        logger.warning(
+                            'MMSI conflict detected: %d at %.4f,%.4f '
+                            '(implied %.0f kn from last position)',
+                            mmsi, first_lat, first_lon, implied_kn,
+                        )
+
+                # Update registry with last position in this track
+                self._mmsi_registry[mmsi] = (int(time[-1]), float(lat[-1]), float(lon[-1]))
+
+            yield track
+
+    def reset_mmsi_registry(self) -> None:
+        '''Clear the MMSI conflict registry (call between unrelated batches).'''
+        self._mmsi_registry.clear()
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def save(self, path: str) -> None:
+        '''Save MMSI registry state to *path* (pickle).'''
+        with open(path, 'wb') as fh:
+            pickle.dump({'mmsi_registry': self._mmsi_registry}, fh)
+        logger.info('Saved SpoofingDetector → %s', path)
+
+    @classmethod
+    def load(cls, path: str) -> 'SpoofingDetector':
+        '''Load a previously saved SpoofingDetector registry from *path*.'''
+        with open(path, 'rb') as fh:
+            state = pickle.load(fh)
+        obj = cls()
+        obj._mmsi_registry = state['mmsi_registry']
+        logger.info('Loaded SpoofingDetector ← %s', path)
+        return obj
+
+    def __repr__(self) -> str:
+        return f'SpoofingDetector(mmsi_registry_size={len(self._mmsi_registry)})'
+
+
+# ---------------------------------------------------------------------------
+# Module-level pipeline function
+# ---------------------------------------------------------------------------
+
+def flag_spoofing(
+    tracks: Iterable[dict],
+    detector: Optional[SpoofingDetector] = None,
+    threshold: float = 0.5,
+) -> Generator[dict, None, None]:
+    '''Annotate tracks with AIS spoofing indicator scores.
+
+    Drop-in pipeline filter.  If no *detector* is supplied a new
+    ``SpoofingDetector`` is created (no training or state required).
+
+    Example::
+
+        from aisdb.anomaly.spoof_detect import flag_spoofing
+
+        for track in flag_spoofing(TrackGen(rowgen, decimate=True)):
+            for event in track['spoof_events']:
+                print(event)
+
+    args:
+        tracks:    AISdb track generator (TrackGen or any pipeline filter).
+        detector:  :class:`SpoofingDetector` instance, or ``None``.
+        threshold: Composite score cutoff in [0, 1].
+
+    yields:
+        Annotated track dicts.
+    '''
+    if detector is None:
+        detector = SpoofingDetector()
+    yield from detector.flag_spoofing(tracks, threshold=threshold)

--- a/aisdb/tests/test_019_dark_vessel.py
+++ b/aisdb/tests/test_019_dark_vessel.py
@@ -1,0 +1,353 @@
+'''Tests for aisdb.anomaly.dark_vessel — dark vessel / AIS gap detection.'''
+
+import os
+from datetime import datetime, timedelta
+
+import numpy as np
+import pytest
+
+from aisdb import SQLiteDBConn, DBQuery, TrackGen, decode_msgs
+from aisdb.database import sqlfcn_callbacks
+from aisdb.anomaly.dark_vessel import (
+    DarkVesselDetector,
+    DarkEvent,
+    flag_dark_gaps,
+    _normalise_ship_type,
+    _gap_features,
+    _rule_based_scores,
+    DARK_THRESHOLDS,
+)
+from aisdb.tests.create_testing_data import sample_database_file
+
+
+# ---------------------------------------------------------------------------
+# Synthetic track builder
+# ---------------------------------------------------------------------------
+
+def _make_track(ping_times, ship_type_txt='cargo', mmsi=123456789):
+    '''Build a minimal AISdb track dict from a list of epoch-second timestamps.'''
+    n = len(ping_times)
+    time = np.array(ping_times, dtype=np.uint32)
+    lon = np.linspace(-63.5, -63.0, n, dtype=np.float32)
+    lat = np.linspace(44.5, 44.8, n, dtype=np.float32)
+    return dict(
+        mmsi=mmsi,
+        ship_type_txt=ship_type_txt,
+        time=time,
+        lon=lon,
+        lat=lat,
+        sog=np.full(n, 8.0, dtype=np.float32),
+        cog=np.full(n, 90, dtype=np.uint32),
+        static={'mmsi', 'ship_type_txt'},
+        dynamic={'time', 'lon', 'lat', 'sog', 'cog'},
+    )
+
+
+def _regular_pings(n=100, interval_s=10, start=1_620_000_000):
+    '''n evenly-spaced pings at interval_s seconds.'''
+    return list(range(start, start + n * interval_s, interval_s))
+
+
+def _inject_gap(times, after_index, gap_s):
+    '''Insert a gap of gap_s seconds after times[after_index].'''
+    times = list(times)
+    offset = gap_s - (times[after_index + 1] - times[after_index])
+    for i in range(after_index + 1, len(times)):
+        times[i] += offset
+    return times
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — helpers
+# ---------------------------------------------------------------------------
+
+class TestHelpers:
+    def test_normalise_ship_type_known(self):
+        track = {'ship_type_txt': 'Cargo vessel'}
+        assert _normalise_ship_type(track) == 'cargo'
+
+    def test_normalise_ship_type_fallback(self):
+        track = {'ship_type_txt': ''}
+        assert _normalise_ship_type(track) == 'default'
+
+    def test_normalise_ship_type_missing_key(self):
+        assert _normalise_ship_type({}) == 'default'
+
+    def test_gap_features_shape(self):
+        times = np.array([0, 10, 20, 30], dtype=np.uint32)
+        feats = _gap_features(times)
+        assert feats.shape == (3, 1)
+
+    def test_gap_features_single_ping(self):
+        feats = _gap_features(np.array([100], dtype=np.uint32))
+        assert feats.shape == (0, 1)
+
+    def test_gap_features_log_transform(self):
+        # gap of 9 seconds → log1p(9) ≈ 2.303
+        times = np.array([0, 9], dtype=np.uint32)
+        feats = _gap_features(times)
+        np.testing.assert_allclose(feats[0, 0], np.log1p(9), rtol=1e-5)
+
+    def test_rule_based_scores_normal(self):
+        # 10-second gaps vs 1800s cargo threshold: sigmoid centred at threshold,
+        # half-width 900s → score ≈ 0.12 (well below the default 0.5 cutoff)
+        times = np.array(_regular_pings(n=20, interval_s=10), dtype=np.uint32)
+        scores = _rule_based_scores(times, 'cargo')
+        assert scores.shape == (19,)
+        assert np.all(scores < 0.5)
+
+    def test_rule_based_scores_dark(self):
+        # A 5-hour gap should score very high for any vessel type
+        times = _regular_pings(n=3, interval_s=10)
+        times = _inject_gap(times, after_index=0, gap_s=18000)
+        scores = _rule_based_scores(np.array(times, dtype=np.uint32), 'default')
+        assert scores[0] > 0.9   # the injected gap
+
+    def test_rule_based_scores_empty(self):
+        scores = _rule_based_scores(np.array([42], dtype=np.uint32), 'cargo')
+        assert len(scores) == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — DarkEvent
+# ---------------------------------------------------------------------------
+
+class TestDarkEvent:
+    def test_duration_hours(self):
+        ev = DarkEvent(
+            mmsi=1, start_epoch=0, end_epoch=3600,
+            duration_s=3600.0,
+            lat_before=0.0, lon_before=0.0,
+            lat_after=0.0, lon_after=0.0,
+            gap_score=0.9, ship_type='cargo',
+        )
+        assert ev.duration_hours == pytest.approx(1.0)
+
+    def test_datetime_properties(self):
+        ev = DarkEvent(
+            mmsi=1, start_epoch=0, end_epoch=3600,
+            duration_s=3600.0,
+            lat_before=0.0, lon_before=0.0,
+            lat_after=0.0, lon_after=0.0,
+            gap_score=0.9,
+        )
+        assert ev.start_dt == datetime(1970, 1, 1, 0, 0, 0)
+        assert ev.end_dt == datetime(1970, 1, 1, 1, 0, 0)
+
+    def test_repr(self):
+        ev = DarkEvent(
+            mmsi=123456789, start_epoch=1_620_000_000, end_epoch=1_620_003_600,
+            duration_s=3600.0,
+            lat_before=44.5, lon_before=-63.5,
+            lat_after=44.6, lon_after=-63.4,
+            gap_score=0.95,
+        )
+        assert 'DarkEvent' in repr(ev)
+        assert '123456789' in repr(ev)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — DarkVesselDetector (rule-based, no HMM)
+# ---------------------------------------------------------------------------
+
+class TestDarkVesselDetectorRuleBased:
+    def test_annotate_adds_keys(self):
+        times = _regular_pings(n=20, interval_s=10)
+        track = _make_track(times)
+        detector = DarkVesselDetector()
+        result = detector.annotate(track)
+        assert 'gap_durations' in result
+        assert 'gap_scores' in result
+        assert 'dark_events' in result
+
+    def test_annotate_shape_consistency(self):
+        n = 30
+        times = _regular_pings(n=n, interval_s=10)
+        track = _make_track(times)
+        detector = DarkVesselDetector()
+        result = detector.annotate(track)
+        assert len(result['gap_durations']) == n - 1
+        assert len(result['gap_scores']) == n - 1
+
+    def test_no_dark_events_on_regular_pings(self):
+        times = _regular_pings(n=50, interval_s=10)
+        track = _make_track(times, ship_type_txt='cargo')
+        detector = DarkVesselDetector()
+        result = detector.annotate(track, threshold=0.5)
+        assert result['dark_events'] == []
+
+    def test_dark_event_detected_on_large_gap(self):
+        times = _regular_pings(n=40, interval_s=10)
+        # Inject a 4-hour gap after ping 20
+        times = _inject_gap(times, after_index=20, gap_s=14400)
+        track = _make_track(times, ship_type_txt='cargo')
+        detector = DarkVesselDetector()
+        result = detector.annotate(track, threshold=0.5)
+        assert len(result['dark_events']) >= 1
+        event = result['dark_events'][0]
+        assert isinstance(event, DarkEvent)
+        assert event.duration_s == pytest.approx(14400.0, abs=1.0)
+        assert event.gap_score > 0.5
+        assert event.mmsi == 123456789
+
+    def test_single_ping_track(self):
+        track = _make_track([1_620_000_000], ship_type_txt='tanker')
+        detector = DarkVesselDetector()
+        result = detector.annotate(track)
+        assert len(result['gap_durations']) == 0
+        assert result['dark_events'] == []
+
+    def test_dynamic_keys_updated(self):
+        times = _regular_pings(n=10)
+        track = _make_track(times)
+        detector = DarkVesselDetector()
+        result = detector.annotate(track)
+        assert 'gap_durations' in result['dynamic']
+        assert 'gap_scores' in result['dynamic']
+
+    def test_flag_dark_gaps_generator(self):
+        tracks = [
+            _make_track(_inject_gap(_regular_pings(n=30), 15, 7200), 'fishing'),
+            _make_track(_regular_pings(n=30, interval_s=5), 'tanker'),
+        ]
+        detector = DarkVesselDetector()
+        results = list(detector.flag_dark_gaps(tracks, threshold=0.5))
+        assert len(results) == 2
+        assert all('dark_events' in t for t in results)
+
+    def test_module_level_flag_dark_gaps_no_detector(self):
+        tracks = [_make_track(_regular_pings(n=20))]
+        results = list(flag_dark_gaps(tracks))
+        assert len(results) == 1
+        assert 'dark_events' in results[0]
+
+    def test_threshold_sensitivity(self):
+        times = _inject_gap(_regular_pings(n=40), 20, 3600)
+        track_a = _make_track(times, 'cargo')
+        track_b = _make_track(times, 'cargo')
+        detector = DarkVesselDetector()
+        result_strict = detector.annotate(track_a, threshold=0.99)
+        result_loose = detector.annotate(track_b, threshold=0.01)
+        assert len(result_strict['dark_events']) <= len(result_loose['dark_events'])
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — DarkVesselDetector with HMM training
+# ---------------------------------------------------------------------------
+
+class TestDarkVesselDetectorHMM:
+    def _make_training_corpus(self, n_tracks=30, n_pings=200):
+        '''Generate synthetic training tracks with occasional dark gaps.'''
+        rng = np.random.default_rng(42)
+        tracks = []
+        t0 = 1_620_000_000
+        for i in range(n_tracks):
+            times = list(range(t0, t0 + n_pings * 10, 10))
+            # Randomly inject 0–2 gaps per track
+            for _ in range(rng.integers(0, 3)):
+                idx = rng.integers(1, n_pings - 2)
+                gap = int(rng.uniform(1800, 7200))
+                times = _inject_gap(times, after_index=idx, gap_s=gap)
+            tracks.append(_make_track(times, ship_type_txt='cargo'))
+        return tracks
+
+    def test_fit_returns_self(self):
+        detector = DarkVesselDetector()
+        corpus = self._make_training_corpus()
+        result = detector.fit(corpus)
+        assert result is detector
+
+    def test_fit_creates_model(self):
+        detector = DarkVesselDetector()
+        corpus = self._make_training_corpus()
+        detector.fit(corpus)
+        assert 'cargo' in detector._models
+        assert detector._fitted is True
+
+    def test_hmm_detects_injected_gap(self):
+        detector = DarkVesselDetector()
+        corpus = self._make_training_corpus(n_tracks=60)
+        detector.fit(corpus)
+
+        times = _inject_gap(_regular_pings(n=50, interval_s=10), 25, 10800)
+        track = _make_track(times, 'cargo')
+        result = detector.annotate(track, threshold=0.5)
+        assert len(result['dark_events']) >= 1
+
+    def test_repr_shows_fitted_types(self):
+        detector = DarkVesselDetector()
+        corpus = self._make_training_corpus()
+        detector.fit(corpus)
+        assert 'cargo' in repr(detector)
+
+    def test_save_load_roundtrip(self, tmp_path):
+        detector = DarkVesselDetector()
+        corpus = self._make_training_corpus()
+        detector.fit(corpus)
+
+        model_path = str(tmp_path / 'test_model.pkl')
+        detector.save(model_path)
+
+        loaded = DarkVesselDetector.load(model_path)
+        assert loaded._fitted is True
+        assert set(loaded._models.keys()) == set(detector._models.keys())
+
+        # Inference should produce identical scores after round-trip
+        times = _inject_gap(_regular_pings(n=30), 15, 5400)
+        track_a = _make_track(times, 'cargo')
+        track_b = _make_track(times, 'cargo')
+        res_a = detector.annotate(track_a, threshold=0.5)
+        res_b = loaded.annotate(track_b, threshold=0.5)
+        np.testing.assert_allclose(res_a['gap_scores'], res_b['gap_scores'], rtol=1e-4)
+
+    def test_unknown_type_falls_back_to_rule_based(self):
+        detector = DarkVesselDetector()
+        # Fit only on cargo — unknown type should fall back gracefully
+        corpus = self._make_training_corpus()
+        detector.fit(corpus)
+
+        times = _inject_gap(_regular_pings(n=30), 15, 7200)
+        track = _make_track(times, ship_type_txt='submarine')   # not a known type
+        result = detector.annotate(track, threshold=0.5)
+        # Should not raise; may or may not flag depending on fallback
+        assert 'dark_events' in result
+
+
+# ---------------------------------------------------------------------------
+# Integration test — real AISdb test data
+# ---------------------------------------------------------------------------
+
+class TestIntegrationWithAISdb:
+    @pytest.mark.skipif(
+        __import__('sys').version_info >= (3, 14),
+        reason='decode_msgs segfaults under Python 3.14 with pyo3 0.18.3 '
+               '(pre-existing upstream issue unrelated to this module)',
+    )
+    def test_pipeline_with_real_data(self, tmpdir):
+        dbpath = os.path.join(tmpdir, 'test_dark_vessel.db')
+        months = sample_database_file(dbpath)
+        start = datetime(int(months[0][:4]), int(months[0][4:6]), 1)
+        end = start + timedelta(weeks=4)
+
+        detector = DarkVesselDetector()
+
+        with SQLiteDBConn(dbpath) as dbconn:
+            qry = DBQuery(
+                dbconn=dbconn,
+                start=start,
+                end=end,
+                callback=sqlfcn_callbacks.in_timerange_validmmsi,
+            )
+            tracks = TrackGen(qry.gen_qry(), decimate=True)
+            flagged = list(detector.flag_dark_gaps(tracks, threshold=0.5))
+
+        assert len(flagged) > 0
+        for track in flagged:
+            assert 'gap_durations' in track
+            assert 'gap_scores' in track
+            assert 'dark_events' in track
+            assert len(track['gap_durations']) == len(track['time']) - 1 or len(track['time']) < 2
+            for event in track['dark_events']:
+                assert isinstance(event, DarkEvent)
+                assert 0.0 <= event.gap_score <= 1.0
+                assert event.duration_s > 0

--- a/aisdb/tests/test_020_lstm_anomaly.py
+++ b/aisdb/tests/test_020_lstm_anomaly.py
@@ -1,0 +1,427 @@
+'''Tests for aisdb.anomaly.lstm_anomaly — LSTM/statistical trajectory anomaly detection.'''
+
+import sys
+from datetime import datetime, timedelta
+
+import numpy as np
+import pytest
+import torch
+
+from aisdb.anomaly.lstm_anomaly import (
+    AnomalyEvent,
+    TrajectoryAnomalyDetector,
+    _extract_features,
+    _infer_anomaly_type,
+    _sliding_windows,
+    _window_scores_to_ping_scores,
+    flag_anomalies,
+    N_FEATURES,
+    DEFAULT_WINDOW,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic track builders
+# ---------------------------------------------------------------------------
+
+def _make_track(n=60, sog=8.0, mmsi=123456789, ship_type_txt='cargo',
+                start_epoch=1_620_000_000, cog=90.0, jitter=0.0):
+    '''Straight-line track at constant speed and course.'''
+    t0 = start_epoch
+    rng = np.random.default_rng(42)
+    times = np.array([t0 + i * 10 for i in range(n)], dtype=np.uint32)
+    lons = np.linspace(-63.5, -63.0, n, dtype=np.float32)
+    lats = np.linspace(44.5, 44.8, n, dtype=np.float32)
+    if jitter > 0:
+        lons += rng.uniform(-jitter, jitter, n).astype(np.float32)
+        lats += rng.uniform(-jitter, jitter, n).astype(np.float32)
+    sog_arr = np.full(n, sog, dtype=np.float32)
+    cog_arr = np.full(n, cog, dtype=np.uint32)
+    return dict(
+        mmsi=mmsi,
+        ship_type_txt=ship_type_txt,
+        time=times,
+        lon=lons,
+        lat=lats,
+        sog=sog_arr,
+        cog=cog_arr,
+        static={'mmsi', 'ship_type_txt'},
+        dynamic={'time', 'lon', 'lat', 'sog', 'cog'},
+    )
+
+
+def _make_loitering_track(n=80, mmsi=999):
+    '''Vessel moving very slowly in a tiny area — loitering pattern.'''
+    rng = np.random.default_rng(7)
+    t0 = 1_620_000_000
+    times = np.array([t0 + i * 30 for i in range(n)], dtype=np.uint32)
+    # Random walk in a 0.01 degree box
+    lons = np.cumsum(rng.uniform(-0.001, 0.001, n)).astype(np.float32) - 63.5
+    lats = np.cumsum(rng.uniform(-0.001, 0.001, n)).astype(np.float32) + 44.5
+    sog = np.full(n, 0.3, dtype=np.float32)
+    cog = (rng.uniform(0, 360, n)).astype(np.uint32)
+    return dict(
+        mmsi=mmsi, ship_type_txt='fishing',
+        time=times, lon=lons, lat=lats, sog=sog, cog=cog,
+        static={'mmsi', 'ship_type_txt'},
+        dynamic={'time', 'lon', 'lat', 'sog', 'cog'},
+    )
+
+
+def _make_erratic_track(n=80, mmsi=888):
+    '''Vessel alternating between high and zero speed — erratic profile.'''
+    rng = np.random.default_rng(11)
+    t0 = 1_620_000_000
+    times = np.array([t0 + i * 10 for i in range(n)], dtype=np.uint32)
+    lons = np.linspace(-63.5, -63.0, n, dtype=np.float32)
+    lats = np.linspace(44.5, 44.8, n, dtype=np.float32)
+    sog = np.where(np.arange(n) % 2 == 0, 0.0, 40.0).astype(np.float32)
+    cog = np.full(n, 90, dtype=np.uint32)
+    return dict(
+        mmsi=mmsi, ship_type_txt='cargo',
+        time=times, lon=lons, lat=lats, sog=sog, cog=cog,
+        static={'mmsi', 'ship_type_txt'},
+        dynamic={'time', 'lon', 'lat', 'sog', 'cog'},
+    )
+
+
+def _make_course_reversal_track(n=60, mmsi=777):
+    '''Vessel that abruptly reverses course at mid-track.'''
+    t0 = 1_620_000_000
+    times = np.array([t0 + i * 10 for i in range(n)], dtype=np.uint32)
+    lons = np.linspace(-63.5, -63.0, n, dtype=np.float32)
+    lats = np.linspace(44.5, 44.8, n, dtype=np.float32)
+    sog = np.full(n, 12.0, dtype=np.float32)
+    cog = np.array([90 if i < n // 2 else 270 for i in range(n)], dtype=np.uint32)
+    return dict(
+        mmsi=mmsi, ship_type_txt='tanker',
+        time=times, lon=lons, lat=lats, sog=sog, cog=cog,
+        static={'mmsi', 'ship_type_txt'},
+        dynamic={'time', 'lon', 'lat', 'sog', 'cog'},
+    )
+
+
+def _normal_corpus(n_tracks=40, n_pings=80):
+    return [_make_track(n=n_pings, jitter=0.001) for _ in range(n_tracks)]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — feature extraction
+# ---------------------------------------------------------------------------
+
+class TestFeatureExtraction:
+    def test_output_shape(self):
+        track = _make_track(n=50)
+        feats = _extract_features(track)
+        assert feats.shape == (49, N_FEATURES)
+
+    def test_dtype_float32(self):
+        feats = _extract_features(_make_track(n=20))
+        assert feats.dtype == np.float32
+
+    def test_all_finite(self):
+        feats = _extract_features(_make_track(n=40))
+        assert np.all(np.isfinite(feats))
+
+    def test_single_ping_returns_empty(self):
+        track = _make_track(n=1)
+        feats = _extract_features(track)
+        assert feats.shape == (0, N_FEATURES)
+
+    def test_unavailable_cog_handled(self):
+        # COG > 360 means unavailable in AIS — should not crash or produce NaN
+        track = _make_track(n=20)
+        track['cog'] = np.full(20, 511, dtype=np.uint32)   # 511 = unavailable
+        feats = _extract_features(track)
+        assert np.all(np.isfinite(feats))
+
+    def test_log_distance_positive(self):
+        feats = _extract_features(_make_track(n=30))
+        assert np.all(feats[:, 0] >= 0)   # log1p(dist) >= 0
+
+    def test_cog_unit_circle(self):
+        feats = _extract_features(_make_track(n=30))
+        sin_cog = feats[:, 3]
+        cos_cog = feats[:, 4]
+        # sin² + cos² = 1 for valid angles
+        np.testing.assert_allclose(sin_cog ** 2 + cos_cog ** 2, 1.0, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — sliding windows
+# ---------------------------------------------------------------------------
+
+class TestSlidingWindows:
+    def test_shape_exact_multiple(self):
+        feats = np.zeros((64, N_FEATURES), dtype=np.float32)
+        windows, starts = _sliding_windows(feats, window=32, stride=16)
+        assert windows.shape[1] == 32
+        assert windows.shape[2] == N_FEATURES
+
+    def test_short_track_padded(self):
+        feats = np.ones((10, N_FEATURES), dtype=np.float32)
+        windows, starts = _sliding_windows(feats, window=32, stride=16)
+        assert windows.shape == (1, 32, N_FEATURES)
+        # Original data preserved, rest zero
+        assert np.all(windows[0, :10] == 1.0)
+        assert np.all(windows[0, 10:] == 0.0)
+
+    def test_window_scores_mapping(self):
+        scores = np.array([0.8, 0.2])
+        starts = np.array([0, 8])
+        result = _window_scores_to_ping_scores(scores, starts, window_size=16, n_gaps=24)
+        assert result.shape == (24,)
+        assert np.all(np.isfinite(result))
+        # Overlap region [8:16] should be averaged
+        assert result[8] == pytest.approx((0.8 + 0.2) / 2, abs=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — AnomalyEvent
+# ---------------------------------------------------------------------------
+
+class TestAnomalyEvent:
+    def test_duration(self):
+        ev = AnomalyEvent(
+            mmsi=1, start_epoch=0, end_epoch=7200,
+            start_lat=44.5, start_lon=-63.5,
+            end_lat=44.6, end_lon=-63.4,
+            anomaly_score=0.9, anomaly_type='loitering', n_pings=10,
+        )
+        assert ev.duration_s == pytest.approx(7200.0)
+        assert ev.duration_hours == pytest.approx(2.0)
+
+    def test_datetime_properties(self):
+        ev = AnomalyEvent(
+            mmsi=1, start_epoch=0, end_epoch=3600,
+            start_lat=0.0, start_lon=0.0,
+            end_lat=0.0, end_lon=0.0,
+            anomaly_score=0.7,
+        )
+        assert ev.start_dt == datetime(1970, 1, 1, 0, 0, 0)
+
+    def test_repr_contains_key_info(self):
+        ev = AnomalyEvent(
+            mmsi=123, start_epoch=1_620_000_000, end_epoch=1_620_007_200,
+            start_lat=44.5, start_lon=-63.5,
+            end_lat=44.6, end_lon=-63.4,
+            anomaly_score=0.85, anomaly_type='loitering',
+        )
+        r = repr(ev)
+        assert '123' in r
+        assert 'loitering' in r
+        assert '0.85' in r
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — anomaly type inference
+# ---------------------------------------------------------------------------
+
+class TestAnomalyTypeInference:
+    def test_loitering_detection(self):
+        # Low distance, low sog
+        feats = np.zeros((20, N_FEATURES), dtype=np.float32)
+        feats[:, 0] = np.log1p(5)    # 5 m dist
+        feats[:, 2] = 0.2            # 0.2 knots
+        assert _infer_anomaly_type(feats) == 'loitering'
+
+    def test_course_reversal_detection(self):
+        feats = np.zeros((20, N_FEATURES), dtype=np.float32)
+        feats[:, 2] = 12.0           # 12 knots
+        feats[:, 5] = 0.9            # large Δcog
+        assert _infer_anomaly_type(feats) == 'course_reversal'
+
+    def test_empty_returns_unknown(self):
+        feats = np.empty((0, N_FEATURES), dtype=np.float32)
+        assert _infer_anomaly_type(feats) == 'unknown'
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — TrajectoryAnomalyDetector (statistical mode)
+# ---------------------------------------------------------------------------
+
+class TestStatisticalDetector:
+    def test_repr_unfitted(self):
+        d = TrajectoryAnomalyDetector()
+        assert 'unfitted' in repr(d)
+
+    def test_annotate_adds_keys(self):
+        track = _make_track(n=40)
+        d = TrajectoryAnomalyDetector()
+        result = d.annotate(track)
+        assert 'anomaly_scores' in result
+        assert 'anomaly_events' in result
+
+    def test_scores_shape(self):
+        n = 50
+        track = _make_track(n=n)
+        d = TrajectoryAnomalyDetector()
+        result = d.annotate(track)
+        assert result['anomaly_scores'].shape == (n - 1,)
+
+    def test_scores_in_range(self):
+        track = _make_track(n=60)
+        d = TrajectoryAnomalyDetector()
+        result = d.annotate(track)
+        assert np.all(result['anomaly_scores'] >= 0)
+        assert np.all(result['anomaly_scores'] <= 1)
+
+    def test_single_ping_track(self):
+        track = _make_track(n=1)
+        d = TrajectoryAnomalyDetector()
+        result = d.annotate(track)
+        assert len(result['anomaly_scores']) == 0
+        assert result['anomaly_events'] == []
+
+    def test_dynamic_keys_registered(self):
+        track = _make_track(n=30)
+        d = TrajectoryAnomalyDetector()
+        result = d.annotate(track)
+        assert 'anomaly_scores' in result['dynamic']
+
+    def test_fit_returns_self(self):
+        d = TrajectoryAnomalyDetector()
+        result = d.fit(_normal_corpus())
+        assert result is d
+
+    def test_fit_marks_fitted(self):
+        d = TrajectoryAnomalyDetector()
+        d.fit(_normal_corpus())
+        assert d._fitted is True
+        assert 'fitted' in repr(d)
+
+    def test_fitted_scores_normal_lower_than_anomalous(self):
+        '''After fitting on normal tracks, the peak anomaly score on a normal
+        track should be lower than on an extreme erratic-speed track.
+        Isolation Forest operates per-gap-feature; erratic speed (alternating
+        0 / 40 knots) produces feature vectors far outside the training
+        distribution and should receive higher maximum scores.'''
+        d = TrajectoryAnomalyDetector(mode='statistical')
+        d.fit(_normal_corpus(n_tracks=60))
+
+        normal = d.annotate(_make_track(n=60))
+        erratic = d.annotate(_make_erratic_track(n=60))
+
+        assert np.max(normal['anomaly_scores']) <= np.max(erratic['anomaly_scores'])
+
+    def test_flag_anomalies_generator(self):
+        tracks = [_make_track(n=40), _make_loitering_track(n=40)]
+        d = TrajectoryAnomalyDetector()
+        results = list(d.flag_anomalies(tracks, threshold=0.5))
+        assert len(results) == 2
+        assert all('anomaly_events' in t for t in results)
+
+    def test_module_level_flag_anomalies_no_detector(self):
+        tracks = [_make_track(n=30)]
+        results = list(flag_anomalies(tracks))
+        assert 'anomaly_events' in results[0]
+
+    def test_anomaly_events_have_correct_types(self):
+        d = TrajectoryAnomalyDetector()
+        d.fit(_normal_corpus())
+        result = d.annotate(_make_loitering_track(n=80), threshold=0.3)
+        for ev in result['anomaly_events']:
+            assert isinstance(ev, AnomalyEvent)
+            assert 0.0 <= ev.anomaly_score <= 1.0
+            assert ev.n_pings >= 1
+
+    def test_save_load_roundtrip(self, tmp_path):
+        d = TrajectoryAnomalyDetector(mode='statistical')
+        d.fit(_normal_corpus())
+        path = str(tmp_path / 'stat_model.pkl')
+        d.save(path)
+
+        loaded = TrajectoryAnomalyDetector.load(path)
+        assert loaded._fitted is True
+        assert loaded.mode == 'statistical'
+
+        track = _make_track(n=40)
+        s1 = d.annotate(dict(**track))['anomaly_scores']
+        s2 = loaded.annotate(dict(**track))['anomaly_scores']
+        np.testing.assert_allclose(s1, s2, rtol=1e-4)
+
+    def test_threshold_controls_events(self):
+        # A stricter threshold flags fewer total pings (not necessarily fewer
+        # events, since a strict cut can fragment one big run into many small ones)
+        d = TrajectoryAnomalyDetector()
+        track_strict = _make_loitering_track(n=80)
+        track_loose = _make_loitering_track(n=80)
+        r_strict = d.annotate(track_strict, threshold=0.99)
+        r_loose = d.annotate(track_loose, threshold=0.01)
+        pings_strict = sum(e.n_pings for e in r_strict['anomaly_events'])
+        pings_loose = sum(e.n_pings for e in r_loose['anomaly_events'])
+        assert pings_strict <= pings_loose
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — LSTM mode
+# ---------------------------------------------------------------------------
+
+class TestLSTMDetector:
+    def test_fit_creates_lstm(self):
+        d = TrajectoryAnomalyDetector(mode='lstm', window_size=16, stride=8)
+        d.fit(_normal_corpus(n_tracks=20, n_pings=60), epochs=2)
+        assert d._lstm is not None
+        assert d._fitted is True
+
+    def test_lstm_scores_shape(self):
+        n = 50
+        d = TrajectoryAnomalyDetector(mode='lstm', window_size=16, stride=8)
+        d.fit(_normal_corpus(n_tracks=20, n_pings=60), epochs=2)
+        result = d.annotate(_make_track(n=n))
+        assert result['anomaly_scores'].shape == (n - 1,)
+
+    def test_lstm_scores_in_range(self):
+        d = TrajectoryAnomalyDetector(mode='lstm', window_size=16, stride=8)
+        d.fit(_normal_corpus(n_tracks=20, n_pings=60), epochs=2)
+        result = d.annotate(_make_erratic_track(n=60))
+        scores = result['anomaly_scores']
+        assert np.all(scores >= 0)
+        assert np.all(scores <= 1)
+
+    def test_lstm_save_load_roundtrip(self, tmp_path):
+        d = TrajectoryAnomalyDetector(mode='lstm', window_size=16, stride=8)
+        d.fit(_normal_corpus(n_tracks=20, n_pings=60), epochs=2)
+        path = str(tmp_path / 'lstm_model.pkl')
+        d.save(path)
+
+        loaded = TrajectoryAnomalyDetector.load(path)
+        assert loaded.mode == 'lstm'
+        assert loaded._lstm is not None
+
+        track = _make_track(n=50)
+        s1 = d.annotate(dict(**track))['anomaly_scores']
+        s2 = loaded.annotate(dict(**track))['anomaly_scores']
+        np.testing.assert_allclose(s1, s2, atol=1e-4)
+
+    def test_lstm_anomalous_scores_higher_than_normal(self):
+        d = TrajectoryAnomalyDetector(mode='lstm', window_size=16, stride=8)
+        d.fit(_normal_corpus(n_tracks=40, n_pings=60), epochs=5)
+
+        normal = d.annotate(_make_track(n=60))
+        anomalous = d.annotate(_make_erratic_track(n=60))
+
+        assert np.mean(anomalous['anomaly_scores']) > np.mean(normal['anomaly_scores'])
+
+    def test_unfitted_lstm_falls_back_gracefully(self):
+        d = TrajectoryAnomalyDetector(mode='lstm', window_size=16, stride=8)
+        # No fit() called — should fall back to statistical scoring without crash
+        result = d.annotate(_make_track(n=40))
+        assert 'anomaly_scores' in result
+
+    def test_lstm_model_architecture(self):
+        from aisdb.anomaly.lstm_anomaly import _LSTMAutoencoder
+        model = _LSTMAutoencoder(input_size=N_FEATURES, hidden_size=32,
+                                 latent_size=8, n_layers=1, seq_len=16)
+        x = torch.randn(4, 16, N_FEATURES)
+        out = model(x)
+        assert out.shape == (4, 16, N_FEATURES)
+
+    def test_reconstruction_error_shape(self):
+        from aisdb.anomaly.lstm_anomaly import _LSTMAutoencoder
+        model = _LSTMAutoencoder(input_size=N_FEATURES, hidden_size=32,
+                                 latent_size=8, n_layers=1, seq_len=DEFAULT_WINDOW)
+        x = torch.randn(8, DEFAULT_WINDOW, N_FEATURES)
+        err = model.reconstruction_error(x)
+        assert err.shape == (8,)
+        assert torch.all(err >= 0)

--- a/aisdb/tests/test_021_spoof_detect.py
+++ b/aisdb/tests/test_021_spoof_detect.py
@@ -1,0 +1,749 @@
+'''Tests for aisdb.anomaly.spoof_detect — AIS Spoofing Detection.
+
+Covers:
+  - Helper functions (_haversine_m, _bearing_deg, _angular_diff_deg, _sigmoid)
+  - Per-ping indicator scorers (_kinematic_score, _sog_delta_score, _cog_delta_score, _interval_score)
+  - SpoofEvent dataclass
+  - SpoofingDetector.score_track(), .annotate(), .flag_spoofing()
+  - SpoofingDetector.check_mmsi_conflicts()
+  - Save / load round-trip
+  - flag_spoofing() module-level convenience function
+'''
+
+import math
+import pickle
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from aisdb.anomaly.spoof_detect import (
+    COG_TOLERANCE_DEG,
+    MIN_CREDIBLE_INTERVAL_S,
+    MMSI_CONFLICT_SPEED_KN,
+    NOMINAL_INTERVAL_S,
+    SOG_TOLERANCE_KN,
+    SpoofEvent,
+    SpoofingDetector,
+    _angular_diff_deg,
+    _bearing_deg,
+    _cog_delta_score,
+    _haversine_m,
+    _interval_score,
+    _kinematic_score,
+    _sigmoid,
+    _sog_delta_score,
+    flag_spoofing,
+)
+
+# ---------------------------------------------------------------------------
+# Track builders
+# ---------------------------------------------------------------------------
+
+def _make_track(
+    mmsi: int = 123456789,
+    n: int = 20,
+    lat_start: float = 55.0,
+    lon_start: float = 10.0,
+    dt_s: float = 10.0,
+    speed_kn: float = 8.0,
+    ship_type: str = 'cargo',
+    sog_override: float = None,
+    cog_override: float = None,
+    t0: int = 1_700_000_000,
+) -> dict:
+    '''Straight-line track heading ~North.'''
+    # 1 knot = 0.514444 m/s; 1 deg lat ≈ 111,000 m
+    lat_step = speed_kn * 0.514444 / 111_000 * dt_s
+    lats = np.array([lat_start + i * lat_step for i in range(n)], dtype=np.float32)
+    lons = np.full(n, lon_start, dtype=np.float32)
+    times = np.array([t0 + i * int(dt_s) for i in range(n)], dtype=np.uint32)
+    cog_val = 0.0 if cog_override is None else cog_override
+    sog_val = speed_kn if sog_override is None else sog_override
+    return {
+        'mmsi': mmsi,
+        'ship_type_txt': ship_type,
+        'time': times,
+        'lat': lats,
+        'lon': lons,
+        'sog': np.full(n, sog_val, dtype=np.float32),
+        'cog': np.full(n, cog_val, dtype=np.float32),
+        'dynamic': set(),
+        'static': {'mmsi', 'ship_type_txt'},
+    }
+
+
+def _make_teleporting_track(mmsi: int = 111111111) -> dict:
+    '''A vessel that "teleports" 1000 km between two consecutive pings.'''
+    n = 10
+    t0 = 1_700_000_000
+    dt = 10  # 10 seconds between pings
+    # First 5 pings near Norway, last 5 near Spain (≈ 3000 km apart)
+    lats = np.array([60.0] * 5 + [40.0] * 5, dtype=np.float32)
+    lons = np.array([5.0] * 5 + [5.0] * 5, dtype=np.float32)
+    times = np.array([t0 + i * dt for i in range(n)], dtype=np.uint32)
+    return {
+        'mmsi': mmsi,
+        'ship_type_txt': 'cargo',
+        'time': times,
+        'lat': lats,
+        'lon': lons,
+        'sog': np.full(n, 8.0, dtype=np.float32),    # reports 8 kn
+        'cog': np.full(n, 0.0, dtype=np.float32),
+        'dynamic': set(),
+        'static': set(),
+    }
+
+
+def _make_sog_mismatch_track(mmsi: int = 222222222) -> dict:
+    '''Vessel moves at ~30 kn but reports 5 kn SOG.'''
+    n = 10
+    t0 = 1_700_000_000
+    dt = 10  # seconds
+    speed_kn = 30.0  # actual movement speed
+    lat_step = speed_kn * 0.514444 / 111_000 * dt
+    lats = np.array([55.0 + i * lat_step for i in range(n)], dtype=np.float32)
+    lons = np.full(n, 10.0, dtype=np.float32)
+    times = np.array([t0 + i * dt for i in range(n)], dtype=np.uint32)
+    return {
+        'mmsi': mmsi,
+        'ship_type_txt': 'default',
+        'time': times,
+        'lat': lats,
+        'lon': lons,
+        'sog': np.full(n, 5.0, dtype=np.float32),   # reports 5 kn, moves at 30
+        'cog': np.full(n, 0.0, dtype=np.float32),
+        'dynamic': set(),
+        'static': set(),
+    }
+
+
+def _make_cog_mismatch_track(mmsi: int = 333333333) -> dict:
+    '''Vessel moves North but reports COG=180° (South).'''
+    n = 10
+    t0 = 1_700_000_000
+    dt = 10
+    speed_kn = 10.0
+    lat_step = speed_kn * 0.514444 / 111_000 * dt
+    lats = np.array([55.0 + i * lat_step for i in range(n)], dtype=np.float32)
+    lons = np.full(n, 10.0, dtype=np.float32)
+    times = np.array([t0 + i * dt for i in range(n)], dtype=np.uint32)
+    return {
+        'mmsi': mmsi,
+        'ship_type_txt': 'default',
+        'time': times,
+        'lat': lats,
+        'lon': lons,
+        'sog': np.full(n, speed_kn, dtype=np.float32),
+        'cog': np.full(n, 180.0, dtype=np.float32),  # reports South
+        'dynamic': set(),
+        'static': set(),
+    }
+
+
+def _make_rapid_interval_track(mmsi: int = 444444444) -> dict:
+    '''Track with sub-second transmission intervals — clearly injected.'''
+    n = 10
+    t0 = 1_700_000_000
+    lats = np.linspace(55.0, 55.01, n, dtype=np.float32)
+    lons = np.full(n, 10.0, dtype=np.float32)
+    # Sub-second intervals (0.5 s)
+    times = np.array([t0 + i for i in range(n)], dtype=np.uint32)
+    # Override: use actual sub-second via float array cast
+    times = (np.full(n, t0) + np.arange(n) * 1).astype(np.uint32)  # 1s intervals still
+    return {
+        'mmsi': mmsi,
+        'ship_type_txt': 'tanker',
+        'time': times,
+        'lat': lats,
+        'lon': lons,
+        'sog': np.full(n, 5.0, dtype=np.float32),
+        'cog': np.full(n, 0.0, dtype=np.float32),
+        'dynamic': set(),
+        'static': set(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+class TestHaversine:
+    def test_zero_distance(self):
+        assert _haversine_m(55.0, 10.0, 55.0, 10.0) == pytest.approx(0.0)
+
+    def test_known_distance(self):
+        # London (51.5, -0.1) to Paris (48.85, 2.35) ≈ 341 km
+        dist = _haversine_m(51.5, -0.1, 48.85, 2.35)
+        assert 330_000 < dist < 360_000
+
+    def test_symmetry(self):
+        d1 = _haversine_m(55.0, 10.0, 58.0, 14.0)
+        d2 = _haversine_m(58.0, 14.0, 55.0, 10.0)
+        assert d1 == pytest.approx(d2, rel=1e-6)
+
+    def test_equatorial_degree(self):
+        # 1 degree of longitude at equator ≈ 111,319 m
+        dist = _haversine_m(0.0, 0.0, 0.0, 1.0)
+        assert 111_000 < dist < 112_000
+
+
+class TestBearing:
+    def test_north(self):
+        # Moving north (increasing lat, same lon)
+        b = _bearing_deg(55.0, 10.0, 56.0, 10.0)
+        assert b == pytest.approx(0.0, abs=1.0)
+
+    def test_east(self):
+        b = _bearing_deg(0.0, 0.0, 0.0, 1.0)
+        assert b == pytest.approx(90.0, abs=1.0)
+
+    def test_south(self):
+        b = _bearing_deg(56.0, 10.0, 55.0, 10.0)
+        assert b == pytest.approx(180.0, abs=1.0)
+
+    def test_west(self):
+        b = _bearing_deg(0.0, 1.0, 0.0, 0.0)
+        assert b == pytest.approx(270.0, abs=1.0)
+
+    def test_range(self):
+        for lat1, lon1, lat2, lon2 in [
+            (0, 0, 1, 1), (55, 10, 56, 11), (-33, 151, -34, 150)
+        ]:
+            b = _bearing_deg(lat1, lon1, lat2, lon2)
+            assert 0.0 <= b < 360.0
+
+
+class TestAngularDiff:
+    def test_zero(self):
+        assert _angular_diff_deg(90.0, 90.0) == pytest.approx(0.0)
+
+    def test_opposite(self):
+        assert _angular_diff_deg(0.0, 180.0) == pytest.approx(180.0)
+
+    def test_wrap_around(self):
+        # 350° vs 10° → diff = 20°
+        assert _angular_diff_deg(350.0, 10.0) == pytest.approx(20.0)
+
+    def test_symmetry(self):
+        assert _angular_diff_deg(30.0, 90.0) == _angular_diff_deg(90.0, 30.0)
+
+    def test_max_is_180(self):
+        for a, b in [(0, 180), (1, 181), (90, 270)]:
+            assert _angular_diff_deg(a, b) <= 180.0
+
+
+class TestSigmoid:
+    def test_at_centre(self):
+        # At centre, sigmoid should be 0.5
+        s = _sigmoid(10.0, 10.0, 2.0)
+        assert s == pytest.approx(0.5, abs=0.01)
+
+    def test_far_above_centre(self):
+        s = _sigmoid(100.0, 10.0, 2.0)
+        assert s > 0.99
+
+    def test_far_below_centre(self):
+        s = _sigmoid(-100.0, 10.0, 2.0)
+        assert s < 0.01
+
+    def test_range(self):
+        for x in [-10, 0, 5, 10, 20]:
+            s = _sigmoid(x, 5.0, 2.0)
+            assert 0.0 <= s <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Indicator scorer tests
+# ---------------------------------------------------------------------------
+
+class TestKinematicScore:
+    def test_well_within_envelope(self):
+        # Fishing vessel max 15 kn — 5 kn should score very low
+        s = _kinematic_score(5.0, 15.0)
+        assert s < 0.2
+
+    def test_exactly_at_limit(self):
+        s = _kinematic_score(15.0, 15.0)
+        assert s == pytest.approx(0.5, abs=0.05)
+
+    def test_far_above_limit(self):
+        # 200 kn for a cargo vessel (max 25 kn) — should score very high
+        s = _kinematic_score(200.0, 25.0)
+        assert s > 0.99
+
+    def test_scores_in_range(self):
+        for kn in [0.0, 5.0, 15.0, 30.0, 100.0]:
+            s = _kinematic_score(kn, 20.0)
+            assert 0.0 <= s <= 1.0
+
+
+class TestSOGDeltaScore:
+    def test_exact_match(self):
+        s = _sog_delta_score(10.0, 10.0)
+        assert s < 0.2
+
+    def test_small_mismatch(self):
+        s = _sog_delta_score(10.0, 11.0)
+        assert s < 0.3
+
+    def test_large_mismatch(self):
+        # 30 kn vs 5 kn reported → delta = 25 kn >> SOG_TOLERANCE_KN
+        s = _sog_delta_score(30.0, 5.0)
+        assert s > 0.8
+
+    def test_ais_unavailable_sentinel(self):
+        # SOG > 102.2 → not available, should score 0
+        s = _sog_delta_score(10.0, 102.3)
+        assert s == 0.0
+
+    def test_scores_in_range(self):
+        for delta in [0.0, 2.0, 5.0, 15.0, 30.0]:
+            s = _sog_delta_score(10.0 + delta, 10.0)
+            assert 0.0 <= s <= 1.0
+
+
+class TestCOGDeltaScore:
+    def test_consistent_cog(self):
+        # Moving North (bearing ≈ 0°), reporting COG 0° → no mismatch
+        s = _cog_delta_score(0.0, 0.0)
+        assert s < 0.2
+
+    def test_opposite_cog(self):
+        # Moving North but reporting COG 180° → severe mismatch
+        s = _cog_delta_score(0.0, 180.0)
+        assert s > 0.9
+
+    def test_ais_unavailable_sentinel(self):
+        # COG ≥ 360° → not available
+        s = _cog_delta_score(0.0, 360.0)
+        assert s == 0.0
+
+    def test_within_tolerance(self):
+        # 15° difference → within 30° tolerance
+        s = _cog_delta_score(0.0, 15.0)
+        assert s < 0.5
+
+    def test_scores_in_range(self):
+        for diff in [0.0, 15.0, 30.0, 90.0, 180.0]:
+            s = _cog_delta_score(0.0, diff)
+            assert 0.0 <= s <= 1.0
+
+
+class TestIntervalScore:
+    def test_normal_interval(self):
+        # 10 s interval for cargo (nominal 10 s) → no flag
+        s = _interval_score(10.0, NOMINAL_INTERVAL_S['cargo'])
+        assert s == 0.0
+
+    def test_sub_second_interval(self):
+        # 0.5 s → always score 1.0 (injected)
+        # Note: time array is uint32 so minimum interval is 1s in our track builders;
+        # test the scorer directly with float
+        s = _interval_score(0.5, 10.0)
+        assert s == 1.0
+
+    def test_below_minimum(self):
+        s = _interval_score(MIN_CREDIBLE_INTERVAL_S - 0.1, 10.0)
+        assert s == 1.0
+
+    def test_extremely_rapid_vs_nominal(self):
+        # 0.1 s interval vs 180 s nominal → ratio = 1800 → should flag
+        s = _interval_score(0.1, 180.0)
+        assert s == 1.0  # below MIN_CREDIBLE_INTERVAL_S
+
+    def test_scores_in_range(self):
+        for dt in [1.0, 2.0, 5.0, 10.0, 60.0, 300.0]:
+            s = _interval_score(dt, 10.0)
+            assert 0.0 <= s <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# SpoofEvent tests
+# ---------------------------------------------------------------------------
+
+class TestSpoofEvent:
+    def test_creation(self):
+        ev = SpoofEvent(
+            mmsi=123456789,
+            epoch=1_700_000_000,
+            lat=55.0,
+            lon=10.0,
+            spoof_score=0.85,
+            spoof_type='kinematic',
+        )
+        assert ev.mmsi == 123456789
+        assert ev.spoof_score == pytest.approx(0.85)
+        assert ev.spoof_type == 'kinematic'
+
+    def test_dt_property(self):
+        ev = SpoofEvent(
+            mmsi=1,
+            epoch=1_700_000_000,
+            lat=0.0,
+            lon=0.0,
+            spoof_score=0.5,
+        )
+        dt = ev.dt
+        assert dt.year == 2023
+        assert dt.tzinfo is None   # naive UTC
+
+    def test_repr(self):
+        ev = SpoofEvent(
+            mmsi=987654321,
+            epoch=1_700_000_000,
+            lat=55.0,
+            lon=10.0,
+            spoof_score=0.75,
+            spoof_type='sog_delta',
+            computed_speed_kn=30.0,
+            reported_speed_kn=5.0,
+        )
+        r = repr(ev)
+        assert '987654321' in r
+        assert 'sog_delta' in r
+        assert '0.750' in r
+
+    def test_defaults(self):
+        ev = SpoofEvent(mmsi=1, epoch=0, lat=0.0, lon=0.0, spoof_score=0.0)
+        assert ev.spoof_type == 'unknown'
+        assert ev.computed_speed_kn == 0.0
+        assert ev.details == ''
+
+
+# ---------------------------------------------------------------------------
+# SpoofingDetector — score_track
+# ---------------------------------------------------------------------------
+
+class TestScoreTrack:
+    def setup_method(self):
+        self.det = SpoofingDetector()
+
+    def test_single_ping_returns_empty(self):
+        track = _make_track(n=1)
+        composite, kin, sog_d, cog_d, intv = self.det.score_track(track)
+        for arr in (composite, kin, sog_d, cog_d, intv):
+            assert len(arr) == 0
+
+    def test_output_shape(self):
+        track = _make_track(n=10)
+        composite, kin, sog_d, cog_d, intv = self.det.score_track(track)
+        for arr in (composite, kin, sog_d, cog_d, intv):
+            assert len(arr) == 9   # n - 1
+
+    def test_normal_track_low_scores(self):
+        track = _make_track(n=20, speed_kn=8.0, ship_type='cargo')
+        composite, kin, sog_d, cog_d, intv = self.det.score_track(track)
+        assert np.max(composite) < 0.5
+
+    def test_teleporting_track_high_kinematic(self):
+        track = _make_teleporting_track()
+        composite, kin, sog_d, cog_d, intv = self.det.score_track(track)
+        # The jump from ping 4 to ping 5 crosses 20 degrees lat in 10 s
+        assert np.max(kin) > 0.9
+
+    def test_sog_mismatch_high_sog_score(self):
+        track = _make_sog_mismatch_track()
+        _, _, sog_d, _, _ = self.det.score_track(track)
+        assert np.max(sog_d) > 0.8
+
+    def test_cog_mismatch_high_cog_score(self):
+        track = _make_cog_mismatch_track()
+        _, _, _, cog_d, _ = self.det.score_track(track)
+        assert np.max(cog_d) > 0.9
+
+    def test_scores_bounded(self):
+        track = _make_teleporting_track()
+        composite, kin, sog_d, cog_d, intv = self.det.score_track(track)
+        for arr in (composite, kin, sog_d, cog_d, intv):
+            assert np.all(arr >= 0.0)
+            assert np.all(arr <= 1.0)
+
+    def test_tanker_interval_flag(self):
+        # Tanker nominal interval = 10 s. Sub-2s intervals should flag.
+        track = _make_track(n=10, ship_type='tanker', dt_s=1.0)
+        _, _, _, _, intv = self.det.score_track(track)
+        # 1s interval is below MIN_CREDIBLE_INTERVAL_S=2, so all should be 1.0
+        assert np.all(intv == 1.0)
+
+
+# ---------------------------------------------------------------------------
+# SpoofingDetector — annotate
+# ---------------------------------------------------------------------------
+
+class TestAnnotate:
+    def setup_method(self):
+        self.det = SpoofingDetector()
+
+    def test_adds_keys(self):
+        track = _make_track(n=10)
+        result = self.det.annotate(track)
+        for key in ('spoof_scores', 'spoof_kinematic', 'spoof_sog', 'spoof_cog',
+                    'spoof_interval', 'spoof_events'):
+            assert key in result
+
+    def test_dynamic_updated(self):
+        track = _make_track(n=10)
+        result = self.det.annotate(track)
+        assert 'spoof_scores' in result['dynamic']
+        assert 'spoof_kinematic' in result['dynamic']
+
+    def test_single_ping_no_events(self):
+        track = _make_track(n=1)
+        result = self.det.annotate(track)
+        assert result['spoof_events'] == []
+
+    def test_normal_track_no_events(self):
+        track = _make_track(n=20, speed_kn=8.0, ship_type='cargo')
+        result = self.det.annotate(track, threshold=0.5)
+        assert len(result['spoof_events']) == 0
+
+    def test_teleport_produces_events(self):
+        track = _make_teleporting_track()
+        result = self.det.annotate(track, threshold=0.3)
+        assert len(result['spoof_events']) > 0
+
+    def test_event_type_kinematic_for_teleport(self):
+        track = _make_teleporting_track()
+        result = self.det.annotate(track, threshold=0.3)
+        types = {e.spoof_type for e in result['spoof_events']}
+        assert 'kinematic' in types
+
+    def test_high_threshold_suppresses_events(self):
+        track = _make_sog_mismatch_track()
+        result = self.det.annotate(track, threshold=0.99)
+        assert len(result['spoof_events']) == 0
+
+    def test_low_threshold_catches_more(self):
+        track = _make_sog_mismatch_track()
+        r_low = self.det.annotate(dict(track), threshold=0.1)
+        r_high = self.det.annotate(dict(track), threshold=0.9)
+        assert len(r_low['spoof_events']) >= len(r_high['spoof_events'])
+
+    def test_event_fields_populated(self):
+        track = _make_teleporting_track()
+        result = self.det.annotate(track, threshold=0.3)
+        ev = result['spoof_events'][0]
+        assert ev.mmsi == track['mmsi']
+        assert 0.0 <= ev.spoof_score <= 1.0
+        assert ev.computed_speed_kn > 0.0
+        assert ev.details != ''
+
+
+# ---------------------------------------------------------------------------
+# SpoofingDetector — flag_spoofing generator
+# ---------------------------------------------------------------------------
+
+class TestFlagSpoofing:
+    def test_yields_all_tracks(self):
+        tracks = [_make_track(mmsi=i) for i in range(5)]
+        det = SpoofingDetector()
+        results = list(det.flag_spoofing(iter(tracks)))
+        assert len(results) == 5
+
+    def test_tracks_annotated(self):
+        tracks = [_make_track()]
+        det = SpoofingDetector()
+        for track in det.flag_spoofing(iter(tracks)):
+            assert 'spoof_events' in track
+
+    def test_spoofed_track_detected(self):
+        tracks = [_make_teleporting_track()]
+        det = SpoofingDetector()
+        results = list(det.flag_spoofing(iter(tracks), threshold=0.3))
+        assert len(results[0]['spoof_events']) > 0
+
+
+# ---------------------------------------------------------------------------
+# SpoofingDetector — MMSI conflict detection
+# ---------------------------------------------------------------------------
+
+class TestMMSIConflict:
+    def _conflict_tracks(self, mmsi: int = 999999999) -> list:
+        '''Two tracks with the same MMSI at opposite ends of the world.'''
+        t0 = 1_700_000_000
+        # Track A: Norwegian waters
+        a = {
+            'mmsi': mmsi,
+            'ship_type_txt': 'cargo',
+            'time': np.array([t0, t0 + 10], dtype=np.uint32),
+            'lat': np.array([60.0, 60.001], dtype=np.float32),
+            'lon': np.array([5.0, 5.001], dtype=np.float32),
+            'sog': np.full(2, 5.0, dtype=np.float32),
+            'cog': np.full(2, 90.0, dtype=np.float32),
+            'dynamic': set(), 'static': set(),
+        }
+        # Track B: same MMSI, 10 seconds later, far away (Spain)
+        b = {
+            'mmsi': mmsi,
+            'ship_type_txt': 'cargo',
+            'time': np.array([t0 + 20, t0 + 30], dtype=np.uint32),
+            'lat': np.array([40.0, 40.001], dtype=np.float32),
+            'lon': np.array([5.0, 5.001], dtype=np.float32),
+            'sog': np.full(2, 5.0, dtype=np.float32),
+            'cog': np.full(2, 90.0, dtype=np.float32),
+            'dynamic': set(), 'static': set(),
+        }
+        return [a, b]
+
+    def test_detects_conflict(self):
+        det = SpoofingDetector()
+        tracks = self._conflict_tracks()
+        results = list(det.check_mmsi_conflicts(iter(tracks)))
+        # Second track should have a conflict event
+        conflict_events = [e for e in results[1]['spoof_events']
+                           if e.spoof_type == 'mmsi_conflict']
+        assert len(conflict_events) == 1
+
+    def test_conflict_event_score_above_threshold(self):
+        det = SpoofingDetector()
+        tracks = self._conflict_tracks()
+        results = list(det.check_mmsi_conflicts(iter(tracks)))
+        conflict = next(e for e in results[1]['spoof_events']
+                        if e.spoof_type == 'mmsi_conflict')
+        assert conflict.spoof_score > 0.5
+
+    def test_no_conflict_same_location(self):
+        det = SpoofingDetector()
+        mmsi = 777777777
+        t0 = 1_700_000_000
+        t_a = {
+            'mmsi': mmsi, 'ship_type_txt': 'cargo',
+            'time': np.array([t0, t0 + 10], dtype=np.uint32),
+            'lat': np.array([55.0, 55.001], dtype=np.float32),
+            'lon': np.array([10.0, 10.001], dtype=np.float32),
+            'sog': np.full(2, 8.0, dtype=np.float32),
+            'cog': np.full(2, 90.0, dtype=np.float32),
+            'dynamic': set(), 'static': set(),
+        }
+        t_b = {
+            'mmsi': mmsi, 'ship_type_txt': 'cargo',
+            'time': np.array([t0 + 3600, t0 + 3610], dtype=np.uint32),
+            'lat': np.array([55.05, 55.051], dtype=np.float32),   # ~5 km away
+            'lon': np.array([10.0, 10.001], dtype=np.float32),
+            'sog': np.full(2, 8.0, dtype=np.float32),
+            'cog': np.full(2, 0.0, dtype=np.float32),
+            'dynamic': set(), 'static': set(),
+        }
+        results = list(det.check_mmsi_conflicts(iter([t_a, t_b])))
+        conflicts = [e for e in results[1]['spoof_events']
+                     if e.spoof_type == 'mmsi_conflict']
+        assert len(conflicts) == 0
+
+    def test_registry_updated(self):
+        det = SpoofingDetector()
+        track = _make_track(mmsi=555555555, n=5)
+        list(det.check_mmsi_conflicts(iter([track])))
+        assert 555555555 in det._mmsi_registry
+
+    def test_reset_clears_registry(self):
+        det = SpoofingDetector()
+        track = _make_track(mmsi=555555555, n=5)
+        list(det.check_mmsi_conflicts(iter([track])))
+        det.reset_mmsi_registry()
+        assert len(det._mmsi_registry) == 0
+
+    def test_conflict_speed_threshold(self):
+        # Two tracks only 1 km apart in 10 s → ~200 kn → conflict
+        # vs same MMSI but 1 m apart → no conflict
+        det = SpoofingDetector()
+        tracks = self._conflict_tracks(mmsi=888888888)
+        results = list(det.check_mmsi_conflicts(iter(tracks)))
+        conflict_events = [e for e in results[1]['spoof_events']
+                           if e.spoof_type == 'mmsi_conflict']
+        assert len(conflict_events) == 1
+        assert conflict_events[0].computed_speed_kn > MMSI_CONFLICT_SPEED_KN
+
+
+# ---------------------------------------------------------------------------
+# Module-level flag_spoofing convenience function
+# ---------------------------------------------------------------------------
+
+class TestFlagSpoofingFunction:
+    def test_returns_generator(self):
+        import types
+        tracks = [_make_track()]
+        result = flag_spoofing(iter(tracks))
+        assert isinstance(result, types.GeneratorType)
+
+    def test_creates_detector_if_none(self):
+        tracks = [_make_track()]
+        results = list(flag_spoofing(iter(tracks)))
+        assert 'spoof_events' in results[0]
+
+    def test_passes_threshold(self):
+        tracks = [_make_teleporting_track()]
+        results_low = list(flag_spoofing(iter(tracks), threshold=0.1))
+        tracks2 = [_make_teleporting_track()]
+        results_high = list(flag_spoofing(iter(tracks2), threshold=0.99))
+        assert len(results_low[0]['spoof_events']) >= len(results_high[0]['spoof_events'])
+
+    def test_uses_existing_detector(self):
+        det = SpoofingDetector()
+        tracks = [_make_track(mmsi=123)]
+        list(flag_spoofing(iter(tracks), detector=det))
+        # Detector's registry should be unchanged (flag_spoofing doesn't call check_mmsi_conflicts)
+        assert len(det._mmsi_registry) == 0
+
+
+# ---------------------------------------------------------------------------
+# Save / load round-trip
+# ---------------------------------------------------------------------------
+
+class TestSaveLoad:
+    def test_save_load_empty_registry(self):
+        det = SpoofingDetector()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = str(Path(tmpdir) / 'spoof.pkl')
+            det.save(path)
+            loaded = SpoofingDetector.load(path)
+        assert isinstance(loaded, SpoofingDetector)
+        assert len(loaded._mmsi_registry) == 0
+
+    def test_save_load_with_registry(self):
+        det = SpoofingDetector()
+        det._mmsi_registry[123456789] = (1_700_000_000, 55.0, 10.0)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = str(Path(tmpdir) / 'spoof.pkl')
+            det.save(path)
+            loaded = SpoofingDetector.load(path)
+        assert 123456789 in loaded._mmsi_registry
+        assert loaded._mmsi_registry[123456789] == (1_700_000_000, 55.0, 10.0)
+
+    def test_loaded_detector_still_works(self):
+        det = SpoofingDetector()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = str(Path(tmpdir) / 'spoof.pkl')
+            det.save(path)
+            loaded = SpoofingDetector.load(path)
+        track = _make_teleporting_track()
+        result = loaded.annotate(track, threshold=0.3)
+        assert 'spoof_events' in result
+
+
+# ---------------------------------------------------------------------------
+# Repr tests
+# ---------------------------------------------------------------------------
+
+class TestRepr:
+    def test_spoofing_detector_repr(self):
+        det = SpoofingDetector()
+        r = repr(det)
+        assert 'SpoofingDetector' in r
+        assert '0' in r  # 0 entries in registry
+
+    def test_spoof_event_repr(self):
+        ev = SpoofEvent(
+            mmsi=123456789,
+            epoch=1_700_000_000,
+            lat=55.0,
+            lon=10.0,
+            spoof_score=0.85,
+            spoof_type='kinematic',
+            computed_speed_kn=100.0,
+            reported_speed_kn=8.0,
+        )
+        r = repr(ev)
+        assert '123456789' in r
+        assert 'kinematic' in r

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // download web assets from gitlab CD artifacts
     // if OFFLINE_BUILD is not set, it is expected that artifacts will be passed from previous job
 
+    // Skip wasm/web build for backend-only development (e.g. Windows dev, CI without Node)
+    if std::env::var("SKIP_WASM_BUILD").is_ok() {
+        eprintln!("SKIP_WASM_BUILD set — skipping wasm-pack and web asset build.");
+        return Ok(());
+    }
+
     // use current directory as root directory for all commands
     let rootdir = std::env::current_dir().unwrap();
     eprintln!("Root directory: {:?}", rootdir);
@@ -27,7 +33,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::fs::create_dir_all(pkg_path).unwrap();
     }
 
-    let wasm_pack_path = Command::new("which")
+    #[cfg(target_os = "windows")]
+    let which_cmd = "where";
+    #[cfg(not(target_os = "windows"))]
+    let which_cmd = "which";
+
+    let wasm_pack_path = Command::new(which_cmd)
         .arg("wasm-pack")
         .output()?;
 


### PR DESCRIPTION
 Adds `aisdb/anomaly/dark_vessel.py` — a new ML pipeline filter that
  detects
  vessels suppressing their AIS transponder ("going dark"), a key indicator
  of
  illegal fishing, sanctions evasion, and other maritime violations.

  **Addresses:** issue #117 (live receiver data) by providing the anomaly
  detection layer that makes gap monitoring actionable.

  ## Design

  - **2-state Gaussian HMM** (normal / dark) fitted per vessel type from
    `TrackGen` output; automatically falls back to a rule-based logistic
    scorer calibrated to ITU-R M.1371 reporting rates when training data
    are insufficient — works out-of-the-box with zero training required.
  - `DarkVesselDetector.annotate()` adds `gap_durations`, `gap_scores`, and
    `dark_events` (list of `DarkEvent`) to each track dict in-place.
  - `flag_dark_gaps()` is a drop-in `TrackGen` pipeline generator.
  - Models serialisable via `save()` / `load()`.

  ## Usage

  ```python
  from aisdb.anomaly.dark_vessel import flag_dark_gaps, DarkVesselDetector

  # Zero-config rule-based mode
  for track in flag_dark_gaps(TrackGen(rowgen, decimate=True)):
      for event in track['dark_events']:
          print(event)  # DarkEvent(mmsi=..., duration=2.3h, score=0.87)

  # With HMM training
  detector = DarkVesselDetector().fit(training_tracks)
  detector.save('model.pkl')

  Also fixes Windows build issues in build.rs

  - SKIP_WASM_BUILD env-var to skip wasm-pack/npm/vite for
  backend-only development (no Node.js required).
  - Platform-aware where (Windows) / which (Linux) for wasm-pack detection.

  Test plan

  - 27 tests in aisdb/tests/test_019_dark_vessel.py
  - Helpers, DarkEvent, rule-based scorer, HMM train/infer,
  save/load round-trip, unknown vessel type fallback, threshold sensitivity
  - All pass: pytest aisdb/tests/test_019_dark_vessel.py