### PR TITLE
Retarget org URLs and metadata: AISViz -> MAPS Lab

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at aisviz@dal.ca.
+reported to the community leaders responsible for enforcement at mapslab@dal.ca.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aisdb"
 edition = "2021"
 version = "1.8.0-alpha"
-authors = [ "AISViz Maintainers // aisviz@dal.ca",]
+authors = [ "AISViz Maintainers // mapslab@dal.ca",]
 
 [lib]
 crate-type = [ "cdylib", "rlib", ]

--- a/LICENSE
+++ b/LICENSE
@@ -630,7 +630,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2023-2026  AISViz, Dalhousie University
+    Copyright (C) 2023-2026  MAPS Lab, Dalhousie University
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To contribute to AISdb or develop it further, set up a build environment with th
 ```sh
 python -m venv AISdb  # Create a virtual environment
 source AISdb/bin/activate  # Activation command for Windows `AISdb\Scripts\activate`
-git clone https://github.com/AISViz/AISdb.git && cd AISdb  # Clone the repository
+git clone https://github.com/MAPS-Lab/AISdb.git && cd AISdb  # Clone the repository
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > install-rust.sh  # Install Rust
 /bin/bash install-rust.sh -q -y  # Run Rust installer
 pip install --upgrade maturin[patchelf]  # Install Maturin for building
@@ -84,7 +84,7 @@ Beyond the Python package, the repository contains the deployable pieces of a se
 
 ## Raster data
 
-Bathymetry, distance-to-shore, and distance-to-port rasters used by `aisdb.webdata` are downloaded on first use from the [data release](https://github.com/AISViz/AISdb/releases/tag/data-v1) of this repository.
+Bathymetry, distance-to-shore, and distance-to-port rasters used by `aisdb.webdata` are downloaded on first use from the [data release](https://github.com/MAPS-Lab/AISdb/releases/tag/data-v1) of this repository.
 
 ## Documentation
 
@@ -92,9 +92,9 @@ Bathymetry, distance-to-shore, and distance-to-port rasters used by `aisdb.webda
 
 ## Related projects
 
-- [AISdb-lite](https://github.com/AISViz/AISdb-lite) is the PostGIS and TimescaleDB first variant that ingests all AIS messages into two global hypertables
-- [NOAA-Integrator](https://github.com/AISViz/NOAA-Integrator) acquires AIS data from NOAA Marine Cadastre and loads it into AISdb-aligned databases
-- [Tutorials](https://github.com/AISViz/Tutorials) collects notebooks with worked examples for AISdb workflows
+- [AISdb-lite](https://github.com/MAPS-Lab/AISdb-lite) is the PostGIS and TimescaleDB first variant that ingests all AIS messages into two global hypertables
+- [NOAA-Integrator](https://github.com/MAPS-Lab/AISdb-NOAA-Integrator) acquires AIS data from NOAA Marine Cadastre and loads it into AISdb-aligned databases
+- [Tutorials](https://github.com/MAPS-Lab/AISdb-Tutorials) collects notebooks with worked examples for AISdb workflows
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ The AISdb team takes security vulnerabilities seriously. If you discover a secur
 ### How to Report
 
 - **Private security advisory (preferred):** Go to the repository's Security tab on GitHub and select "Report a vulnerability". This opens a private advisory visible only to you and the maintainers.
-- **Email:** Send an email to aisviz@dal.ca. Please include a detailed description of the issue and the steps to reproduce the vulnerability. If possible, include patches, scripts, or other resources that could help evaluate the vulnerability.
+- **Email:** Send an email to mapslab@dal.ca. Please include a detailed description of the issue and the steps to reproduce the vulnerability. If possible, include patches, scripts, or other resources that could help evaluate the vulnerability.
 
 ### Response Expectations
 

--- a/aisdb/denoising_encoder.py
+++ b/aisdb/denoising_encoder.py
@@ -260,7 +260,7 @@ def remove_pings_wrt_speed(tracks, speed_threshold):
 
 
 class InlandDenoising:
-    data_url = "https://github.com/AISViz/AISdb/releases/download/data-v1/geo_land_water_NorthAmerica.7z"
+    data_url = "https://github.com/MAPS-Lab/AISdb/releases/download/data-v1/geo_land_water_NorthAmerica.7z"
 
     def __init__(self, data_dir, land_cache="land.pkl", water_cache="water.pkl"):
         download_unzip(self.data_url, data_dir, bytesize=337401807)

--- a/aisdb/webdata/bathymetry.py
+++ b/aisdb/webdata/bathymetry.py
@@ -15,8 +15,8 @@ from aisdb.webdata.load_raster import RasterFile
 
 # GEBCO 2022 grid split into two archives to fit release asset limits
 urls = (
-    "https://github.com/AISViz/AISdb/releases/download/data-v1/raster-bathy-1.7z",
-    "https://github.com/AISViz/AISdb/releases/download/data-v1/raster-bathy-2.7z",
+    "https://github.com/MAPS-Lab/AISdb/releases/download/data-v1/raster-bathy-1.7z",
+    "https://github.com/MAPS-Lab/AISdb/releases/download/data-v1/raster-bathy-2.7z",
 )
 
 

--- a/aisdb/webdata/shore_dist.py
+++ b/aisdb/webdata/shore_dist.py
@@ -97,7 +97,7 @@ def download_unzip(data_url, data_dir, bytesize=0, timeout=(10, 30)):
 
 class ShoreDist(RasterFile):
     # This is self-stored data to easy the deployment process
-    data_url = "https://github.com/AISViz/AISdb/releases/download/data-v1/raster-shore.7z"
+    data_url = "https://github.com/MAPS-Lab/AISdb/releases/download/data-v1/raster-shore.7z"
 
     def __init__(self, data_dir, tif_filename='distance-from-shore.tif'):
         download_unzip(self.data_url, data_dir, bytesize=39911958)
@@ -134,7 +134,7 @@ class ShoreDist(RasterFile):
 
 class PortDist(RasterFile):
     # This is self-stored data to ease the deployment process
-    data_url = "https://github.com/AISViz/AISdb/releases/download/data-v1/raster-ports.7z"
+    data_url = "https://github.com/MAPS-Lab/AISdb/releases/download/data-v1/raster-ports.7z"
 
     def __init__(self, data_dir, tif_filename='distance-from-port-v20201104.tiff'):
         download_unzip(self.data_url, data_dir, bytesize=1263005549)
@@ -171,7 +171,7 @@ class PortDist(RasterFile):
 
 class CoastDist(RasterFile):
     # This is self-stored data to ease the deployment process
-    data_url = "https://github.com/AISViz/AISdb/releases/download/data-v1/raster-coast.7z"
+    data_url = "https://github.com/MAPS-Lab/AISdb/releases/download/data-v1/raster-coast.7z"
 
     def __init__(self, data_dir, tif_filename='GMT_intermediate_coast_distance_01d.tif'):
         download_unzip(self.data_url, data_dir, bytesize=58802115)

--- a/aisdb_lib/Cargo.toml
+++ b/aisdb_lib/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 version = "1.8.0-alpha"
 name = "aisdb-lib"
-authors = [ "AISViz Maintainers // aisviz@dal.ca",]
+authors = [ "AISViz Maintainers // mapslab@dal.ca",]
 edition = "2021"
 include = [ "../aisdb/aisdb_sql", "/src/*",]
 build = "build.rs"
 readme = "../README.md"
 description = "AIS Database and Processing Utils"
 homepage = "https://aisviz.cs.dal.ca/"
-repository = "https://github.com/AISViz/AISdb"
+repository = "https://github.com/MAPS-Lab/AISdb"
 documentation = "https://aisviz.gitbook.io/documentation/"
 license-file = "../LICENSE"
 

--- a/client_webassembly/Cargo.toml
+++ b/client_webassembly/Cargo.toml
@@ -2,12 +2,12 @@
 name = "client"
 version = "1.8.0-alpha"
 edition = "2021"
-authors = [ "AISViz Maintainers // aisviz@dal.ca",]
+authors = [ "AISViz Maintainers // mapslab@dal.ca",]
 readme = "../README.md"
 description = "AIS Database and Processing Utils - Web Client WASM functions"
 homepage = "https://aisviz.cs.dal.ca/"
 documentation = "https://aisviz.gitbook.io/documentation/"
-repository = "https://github.com/AISViz/AISdb"
+repository = "https://github.com/MAPS-Lab/AISdb"
 license-file = "../LICENSE"
 
 [lib]

--- a/database_server/Cargo.toml
+++ b/database_server/Cargo.toml
@@ -2,12 +2,12 @@
 name = "aisdb-db-server"
 version = "1.8.0-alpha"
 edition = "2021"
-authors = [ "AISViz Maintainers // aisviz@dal.ca",]
+authors = [ "AISViz Maintainers // mapslab@dal.ca",]
 readme = "../README.md"
 description = "AIS Database and Processing Utils - Database Server"
 homepage = "https://aisviz.cs.dal.ca/"
 documentation = "https://aisviz.gitbook.io/documentation/"
-repository = "https://github.com/AISViz/AISdb"
+repository = "https://github.com/MAPS-Lab/AISdb"
 license-file = "../LICENSE"
 
 [lib]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@ from datetime import datetime
 # -- Project information -----------------------------------------------------
 
 project = "AISDB"
-copyright = f"{datetime.today().year}, AISViz"
+copyright = f"{datetime.today().year}, MAPS Lab"
 author = "AISViz"
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ dependencies = [
 
 [[project.authors]]
 name = "AISViz Maintainers"
-email = "aisviz@dal.ca"
+email = "mapslab@dal.ca"
 
 [project.urls]
 homepage = "https://aisviz.cs.dal.ca/"
-repository = "https://github.com/AISViz/AISdb"
+repository = "https://github.com/MAPS-Lab/AISdb"
 documentation = "https://aisviz.gitbook.io/documentation/"
 tutorials = "https://aisviz.gitbook.io/tutorials/"
 

--- a/receiver/Cargo.toml
+++ b/receiver/Cargo.toml
@@ -2,11 +2,11 @@
 name = "aisdb-receiver"
 version = "1.8.0-alpha"
 edition = "2021"
-authors = [ "AISViz Maintainers // aisviz@dal.ca",]
+authors = [ "AISViz Maintainers // mapslab@dal.ca",]
 readme = "../README.md"
 description = "AISDB Receiver"
 homepage = "https://aisviz.cs.dal.ca/"
-repository = "https://github.com/AISViz/AISdb"
+repository = "https://github.com/MAPS-Lab/AISdb"
 documentation = "https://aisviz.gitbook.io/documentation/"
 license-file = "../LICENSE"
 


### PR DESCRIPTION
Part of the AISViz -> MAPS Lab org rebrand. Changes: repository/clone/release-asset URLs (README, Cargo.toml x4, pyproject.toml, and the raster download URLs in aisdb/webdata + denoising_encoder) repointed to github.com/MAPS-Lab, with the AISdb-NOAA-Integrator / AISdb-Tutorials repo renames folded into the Related-projects links; LICENSE + docs/source/conf.py copyright holder -> MAPS Lab; contact email -> mapslab@dal.ca. Kept unchanged: the AISViz product name, aisviz.cs.dal.ca, aisviz.gitbook.io, the 'AISViz web API' reference, and the example db name. Note: docs author is left as 'AISViz' (product); say the word to switch it to MAPS Lab too.