### PR TITLE
docs: reconcile Sphinx config, version strings, and dead toctree entries

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ authors:
   - family-names: Spadon
     given-names: Gabriel
     affiliation: "MAPS Lab, Dalhousie University"
-version: "1.8.0a0"
+version: "1.8.0-alpha"
 date-released: "2026-07-06"
 url: "https://github.com/MAPS-Lab/AISdb"
 repository-code: "https://github.com/MAPS-Lab/AISdb"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Bathymetry, distance-to-shore, and distance-to-port rasters used by `aisdb.webda
 
 ## Documentation
 
-[docs](https://aisviz.gitbook.io/documentation/) · [tutorials](https://aisviz.gitbook.io/tutorials/) · [API reference](https://aisviz.cs.dal.ca/AISdb/) · [website](https://aisviz.cs.dal.ca/)
+[docs](https://aisviz.gitbook.io/documentation/) · [tutorials](https://aisviz.gitbook.io/tutorials/) · [API reference](https://maps-lab.github.io/AISdb/) · [website](https://aisviz.cs.dal.ca/)
 
 ## Related projects
 
@@ -105,7 +105,7 @@ If you use AISdb in your work, please cite it. Citation metadata lives in [CITAT
   author    = {Spadon, Gabriel},
   title     = {AISdb},
   year      = {2026},
-  version   = {1.8.0a0},
+  version   = {1.8.0-alpha},
   publisher = {MAPS Lab, Dalhousie University},
   url       = {https://github.com/MAPS-Lab/AISdb},
   license   = {AGPL-3.0}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,15 +10,21 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import importlib.metadata
 from datetime import datetime
 
-# import aisdb
+try:
+    _version = importlib.metadata.version("aisdb")
+except importlib.metadata.PackageNotFoundError:
+    _version = "0.0.0+unknown"
 
 # -- Project information -----------------------------------------------------
 
 project = "AISDB"
 copyright = f"{datetime.today().year}, MAPS Lab"
 author = "MAPS Lab"
+version = ".".join(_version.split(".")[:2])
+release = _version
 
 # -- General configuration ---------------------------------------------------
 
@@ -55,7 +61,7 @@ html_theme_options = {}
 # html_static_path = ['_static']
 # html_static_path = ['.']
 
-html_favicon = "../../aisdb_web/map/public/favicon.svg"
+html_favicon = "https://aisviz.cs.dal.ca/favicon.svg"
 
 html_css_files = [
     #'custom.css',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,6 @@ AISDB Docs: Index
 
    api/aisdb
    api/aisdb.*
-   api/modules
 
 Indices and tables
 ==================


### PR DESCRIPTION
## What
- Add version/release to Sphinx conf.py via importlib.metadata (built docs now show version)
- Fix favicon to use absolute URL instead of fragile ../../ path
- Remove dead `api/modules` toctree entry (build_docs.sh uses `--no-toc`)
- Align CITATION.cff and README BibTeX version to `1.8.0-alpha` (matches git tag)
- Update API reference URL to canonical `maps-lab.github.io/AISdb/`

## Files changed
4 files, +11 -6