### PR TITLE
fix(lib): drop redundant references in format! arguments

### DIFF
--- a/aisdb_lib/src/decode.rs
+++ b/aisdb_lib/src/decode.rs
@@ -197,9 +197,9 @@ fn validate_file_ext(filename: std::path::PathBuf) -> Result<(), String> {
         Some(ext_os_str) => match ext_os_str.to_str() {
             Some("nm4") | Some("NM4") | Some("nmea") | Some("NMEA") | Some("rx") | Some("txt")
             | Some("RX") | Some("TXT") => Ok(()),
-            _ => Err(format!("unknown file type! {:?}", &filename)),
+            _ => Err(format!("unknown file type! {filename:?}")),
         },
-        _ => Err(format!("unknown file type! {:?}", &filename)),
+        _ => Err(format!("unknown file type! {filename:?}")),
     }
 }
 


### PR DESCRIPTION
The `rust` job is failing on every open pull request in this repository, and the cause is two lines rather than anything about the dependencies being bumped.

`clippy::useless_borrows_in_formatting` is denied by that job (`-D warnings`), and `aisdb_lib/src/decode.rs` still passes `&filename` into `format!` at lines 200 and 202:

```
error: redundant reference in `format!` argument
   --> src/decode.rs:200:57
error: could not compile `aisdb-lib` (lib) due to 2 previous errors
```

Both now use the inline capture, `format!("unknown file type! {filename:?}")`. Verified with `cargo clippy -p aisdb-lib --all-targets -- -D warnings`, which is clean.

(The full-workspace clippy cannot run locally here because the build script requires `wasm-pack`, which is not installed; the failing crate was the library, and that is clean.)