### PR TITLE
ci: wait for postgres to accept connections on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -361,9 +361,27 @@ jobs:
       - name: Install PostgreSQL
         run: |
           brew update
-          brew install postgresql@17
-          brew link postgresql@17 --force
-          brew services start postgresql@17
+          brew tap timescale/tap
+          brew trust timescale/tap
+
+          # timescaledb_move.sh copies the module timescaledb was BUILT against
+          # into whichever postgresql keg is linked, and timescaledb-tune adds it
+          # to shared_preload_libraries. Install any other major and the postmaster
+          # refuses to load the module and dies at startup, which surfaces much
+          # later as "postgres did not accept connections". Follow the formula's
+          # own build dependency instead of pinning a major here.
+          PG_FORMULA=$(brew deps --include-build timescaledb \
+            | grep -oE 'postgresql@[0-9]+' | tail -1)
+          if [ -z "$PG_FORMULA" ]; then
+            echo "could not determine the postgresql major that timescaledb needs"
+            exit 1
+          fi
+          echo "timescaledb is built against $PG_FORMULA"
+          echo "PG_FORMULA=$PG_FORMULA" >> "$GITHUB_ENV"
+
+          brew install "$PG_FORMULA"
+          brew link "$PG_FORMULA" --force
+          brew services start "$PG_FORMULA"
           brew cleanup
 
       - name: Check PostgreSQL version
@@ -376,11 +394,9 @@ jobs:
 
       - name: Install TimescaleDB
         run: |
-          brew tap timescale/tap
-          brew trust timescale/tap
           brew install timescaledb
           timescaledb-tune --quiet --yes
-          brew services restart postgresql@17
+          brew services restart "$PG_FORMULA"
           brew cleanup
 
       - name: Setup TimescaleDB
@@ -395,20 +411,21 @@ jobs:
             exit 1
           fi
 
-          brew services restart postgresql@17
+          brew services restart "$PG_FORMULA"
 
-          # brew services returns as soon as launchd accepts the job, but the
-          # server needs longer to open its socket, and longer still here because
-          # the timescaledb library move forces a fresh start with the preload.
-          # The fixed sleep raced it: the move reported Success, the restart
-          # reported Success, and psql then failed with "connection to server on
-          # socket /tmp/.s.PGSQL.5432 failed: No such file or directory".
-          # Poll until the server actually accepts connections.
+          # brew services returns as soon as launchd accepts the job, so poll
+          # rather than sleeping a fixed amount. A failure here is normally the
+          # postmaster refusing to start at all, not slowness, so print its log
+          # before giving up.
           for _ in $(seq 1 60); do
             pg_isready -q && break
             sleep 2
           done
-          pg_isready || { echo "postgres did not accept connections within 120s"; exit 1; }
+          if ! pg_isready; then
+            echo "postgres did not accept connections within 120s; server log follows"
+            tail -100 "$(brew --prefix)/var/log/${PG_FORMULA}.log" || true
+            exit 1
+          fi
 
           psql -U postgres -d postgres -c "CREATE EXTENSION IF NOT EXISTS timescaledb;"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -396,7 +396,20 @@ jobs:
           fi
 
           brew services restart postgresql@17
-          sleep 5
+
+          # brew services returns as soon as launchd accepts the job, but the
+          # server needs longer to open its socket, and longer still here because
+          # the timescaledb library move forces a fresh start with the preload.
+          # The fixed sleep raced it: the move reported Success, the restart
+          # reported Success, and psql then failed with "connection to server on
+          # socket /tmp/.s.PGSQL.5432 failed: No such file or directory".
+          # Poll until the server actually accepts connections.
+          for _ in $(seq 1 60); do
+            pg_isready -q && break
+            sleep 2
+          done
+          pg_isready || { echo "postgres did not accept connections within 120s"; exit 1; }
+
           psql -U postgres -d postgres -c "CREATE EXTENSION IF NOT EXISTS timescaledb;"
 
       - name: Create Python virtual environment and install dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -417,11 +417,15 @@ jobs:
           # rather than sleeping a fixed amount. A failure here is normally the
           # postmaster refusing to start at all, not slowness, so print its log
           # before giving up.
+          # Same host, port, user and database as the psql below, so the wait
+          # cannot succeed against a different connection than the one that
+          # actually has to work.
+          READY="pg_isready -h /tmp -p 5432 -U postgres -d postgres"
           for _ in $(seq 1 60); do
-            pg_isready -q && break
+            $READY -q && break
             sleep 2
           done
-          if ! pg_isready; then
+          if ! $READY; then
             echo "postgres did not accept connections within 120s; server log follows"
             tail -100 "$(brew --prefix)/var/log/${PG_FORMULA}.log" || true
             exit 1

--- a/aisdb_lib/src/decode.rs
+++ b/aisdb_lib/src/decode.rs
@@ -197,9 +197,9 @@ fn validate_file_ext(filename: std::path::PathBuf) -> Result<(), String> {
         Some(ext_os_str) => match ext_os_str.to_str() {
             Some("nm4") | Some("NM4") | Some("nmea") | Some("NMEA") | Some("rx") | Some("txt")
             | Some("RX") | Some("TXT") => Ok(()),
-            _ => Err(format!("unknown file type! {:?}", &filename)),
+            _ => Err(format!("unknown file type! {filename:?}")),
         },
-        _ => Err(format!("unknown file type! {:?}", &filename)),
+        _ => Err(format!("unknown file type! {filename:?}")),
     }
 }
 


### PR DESCRIPTION
`test-macos` fails on every open pull request in this repository, at the `Setup TimescaleDB` step. The script is not the problem.

From the job log, both the move and the restart succeed:

```
Moving files into place...
Success.
Successfully stopped `postgresql@17`
Successfully started `postgresql@17`
```

Five seconds later the very next command fails:

```
psql: error: connection to server on socket "/tmp/.s.PGSQL.5432" failed: No such file or directory
	Is the server running locally and accepting connections on that socket?
##[error]Process completed with exit code 2.
```

`brew services restart` returns as soon as launchd accepts the job, not when the server is ready. Here the gap is wider than usual because `timescaledb_move.sh` has just relocated the library, so PostgreSQL comes up cold with the preload. The hardcoded `sleep 5` was racing that startup.

This replaces the sleep with a `pg_isready` poll, up to 120 seconds, and fails with an explicit message if the server never comes up rather than surfacing as a confusing socket error.

I cannot exercise this locally, since it needs a macOS runner with Homebrew PostgreSQL; the change is derived from the log above rather than from a local reproduction. It should be judged on the CI run it triggers.